### PR TITLE
Telekin u_val('weight') Calls

### DIFF
--- a/powers/telekinesis_eoc.json
+++ b/powers/telekinesis_eoc.json
@@ -50,7 +50,7 @@
         "math": [
           "u_weight_ratio",
           "=",
-          "(((u_telekinesis_power_level * 25) * u_telekinesis_intelligence * u_nether_attunement_telekinesis_scaling) + 10) / (u_val('weight') / 1000000)"
+          "(((u_telekinesis_power_level * 25) * u_telekinesis_intelligence * u_nether_attunement_telekinesis_scaling) + 10) / (u_weight() / 1000000)"
         ]
       },
       { "math": [ "u_telekinesis_shove_spell_level", "=", "clamp(((u_weight_ratio - 1) * 2), 0, 30)" ] },
@@ -90,7 +90,7 @@
         "math": [
           "u_weight_ratio",
           "=",
-          "(((u_telekinesis_power_level * 25) * u_telekinesis_intelligence * u_nether_attunement_telekinesis_scaling) + 10) / (u_val('weight') / 1000000)"
+          "(((u_telekinesis_power_level * 25) * u_telekinesis_intelligence * u_nether_attunement_telekinesis_scaling) + 10) / (u_weight() / 1000000)"
         ]
       },
       { "math": [ "u_telekinesis_pull_spell_level", "=", "clamp(((u_weight_ratio - 1) * 2), 0, 30)" ] },
@@ -150,7 +150,7 @@
         "math": [
           "u_weight_ratio",
           "=",
-          "(((u_telekinesis_power_level * 150) * u_telekinesis_intelligence * u_nether_attunement_telekinesis_scaling) + 100) / (u_val('weight') / 1000000)"
+          "(((u_telekinesis_power_level * 150) * u_telekinesis_intelligence * u_nether_attunement_telekinesis_scaling) + 100) / (u_weight() / 1000000)"
         ]
       },
       { "math": [ "u_telekinesis_shove_spell_level", "=", "clamp(((u_weight_ratio - 1) * 2), 0, 20)" ] },
@@ -180,7 +180,7 @@
         "math": [
           "u_weight_ratio",
           "=",
-          "(((u_telekinesis_power_level * 150) * u_telekinesis_intelligence * u_nether_attunement_telekinesis_scaling) + 100) / (u_val('weight') / 1000000)"
+          "(((u_telekinesis_power_level * 150) * u_telekinesis_intelligence * u_nether_attunement_telekinesis_scaling) + 100) / (u_weight() / 1000000)"
         ]
       },
       { "math": [ "u_telekinesis_pull_spell_level", "=", "clamp(((u_weight_ratio - 1) * 2), 0, 20)" ] },


### PR DESCRIPTION
## Description
PR to merge changes made in v1.01-hotfix8 to the power-backports branch.

## PR Type
- [x] Bug Fix
- [ ] Code Refactor
- [ ] Doc Changes
- [ ] New Asset(s)
- [ ] New Feature(s)

## PR Size
- [ ] One-line
- [x] Small
- [ ] Medium
- [ ] Large

## Testing
No conflicts between branches for this change.

## Notes
I probably need to revisit the backported telekin spells for if they need u_weight()/u_volume() additions.