### PR TITLE
Fix Electron Overflow EoC

### DIFF
--- a/powers/electrokinesis_concentration_eocs.json
+++ b/powers/electrokinesis_concentration_eocs.json
@@ -423,7 +423,7 @@
       },
       { "run_eocs": "EOC_ELECTROKIN_PERSONAL_BATTERY_EFFECT" }
     ]
-        },
+  },
   {
     "type": "effect_on_condition",
     "id": "EOC_ELECTROKIN_PERSONAL_BATTERY_EFFECT_GET_ITEM_COUNT",


### PR DESCRIPTION
## Description
Fixed 'Power Overflow' as it was referencing an obsolete EoC.

## PR Type
- [x] Bug Fix
- [ ] Code Refactor
- [ ] Doc Changes
- [ ] New Asset(s)
- [ ] New Feature(s)

## PR Size
- [ ] One-line
- [x] Small
- [ ] Medium
- [ ] Large

## Testing
<img width="547" height="77" alt="image" src="https://github.com/user-attachments/assets/a122f626-5475-4ce7-b0f3-793c4567c228" />
<img width="398" height="73" alt="image" src="https://github.com/user-attachments/assets/b0569e7a-c1f9-44b4-99bd-4c912c95a768" />


## Notes
Thanks to 'WartedEMS' for the report.
<img width="559" height="426" alt="image" src="https://github.com/user-attachments/assets/743e24ea-ee9d-48f2-a4d6-a0d20b84fa1c" />