### PR TITLE
Fix Blazing Aura

### DIFF
--- a/emits.json
+++ b/emits.json
@@ -169,5 +169,12 @@
     "intensity": 2,
     "chance": 1,
     "qty": 10
+  },
+  {
+    "id": "emit_radiation_aura_fields",
+    "type": "emit",
+    "field": "fd_radiation_aura",
+    "intensity": 1,
+    "qty": 15
   }
 ]

--- a/fields.json
+++ b/fields.json
@@ -1,5 +1,27 @@
 [
   {
+    "id": "fd_tear_in_reality_temporary",
+    "type": "field_type",
+    "intensity_levels": [
+      { "name": "lingering distortion", "color": "light_gray", "sym": "*", "dangerous": true },
+      {
+        "name": "crack in reality",
+        "color": "magenta",
+        "transparent": false,
+        "monster_spawn_chance": 60,
+        "monster_spawn_count": 1,
+        "monster_spawn_radius": 1,
+        "monster_spawn_group": "GROUP_NETHER_REALITY_TEAR_FIELD"
+      }
+    ],
+    "description_affix": "under",
+    "priority": 8,
+    "display_items": true,
+    "display_field": true,
+    "looks_like": "fd_fatigue",
+    "half_life": "10 minutes"
+  },
+  {
     "id": "fd_pyrokinetic_summon_heat_1",
     "type": "field_type",
     "intensity_levels": [
@@ -90,6 +112,670 @@
     "phase": "gas"
   },
   {
+    "id": "fd_pyrokinetic_aura",
+    "type": "field_type",
+    "intensity_levels": [
+      {
+        "name": "burning air",
+        "sym": "&",
+        "convection_temperature_mod": 10,
+        "dangerous": true,
+        "effects": [
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 1,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "head",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 1,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "arm_l",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 1,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "arm_r",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 1,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "leg_l",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 1,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "leg_r",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 1,
+            "immune_inside_vehicle": true
+          }
+        ]
+      },
+      {
+        "color": "yellow",
+        "convection_temperature_mod": 20,
+        "dangerous": true,
+        "effects": [
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 2,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "head",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 2,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "arm_l",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 2,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "arm_r",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 2,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "leg_l",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 2,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "leg_r",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 2,
+            "immune_inside_vehicle": true
+          }
+        ]
+      },
+      {
+        "color": "yellow",
+        "convection_temperature_mod": 30,
+        "dangerous": true,
+        "effects": [
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 3,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "head",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 3,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "arm_l",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 3,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "arm_r",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 3,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "leg_l",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 3,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "leg_r",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 3,
+            "immune_inside_vehicle": true
+          }
+        ]
+      },
+      {
+        "color": "yellow",
+        "convection_temperature_mod": 40,
+        "dangerous": true,
+        "effects": [
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 4,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "head",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 4,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "arm_l",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 4,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "arm_r",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 4,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "leg_l",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 4,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "leg_r",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 4,
+            "immune_inside_vehicle": true
+          }
+        ]
+      },
+      {
+        "color": "yellow",
+        "convection_temperature_mod": 50,
+        "dangerous": true,
+        "effects": [
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 5,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "head",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 5,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "arm_l",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 5,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "arm_r",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 5,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "leg_l",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 5,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "leg_r",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 5,
+            "immune_inside_vehicle": true
+          }
+        ]
+      },
+      {
+        "color": "red",
+        "convection_temperature_mod": 60,
+        "dangerous": true,
+        "effects": [
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 6,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "head",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 6,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "arm_l",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 6,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "arm_r",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 6,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "leg_l",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 6,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "leg_r",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 6,
+            "immune_inside_vehicle": true
+          }
+        ]
+      },
+      {
+        "color": "red",
+        "convection_temperature_mod": 70,
+        "dangerous": true,
+        "effects": [
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 7,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "head",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 7,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "arm_l",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 7,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "arm_r",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 7,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "leg_l",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 7,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "leg_r",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 7,
+            "immune_inside_vehicle": true
+          }
+        ]
+      },
+      {
+        "color": "red",
+        "convection_temperature_mod": 80,
+        "dangerous": true,
+        "effects": [
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 8,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "head",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 8,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "arm_l",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 8,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "arm_r",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 8,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "leg_l",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 8,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "leg_r",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 8,
+            "immune_inside_vehicle": true
+          }
+        ]
+      },
+      {
+        "color": "red",
+        "convection_temperature_mod": 90,
+        "dangerous": true,
+        "effects": [
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 9,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "head",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 9,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "arm_l",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 9,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "arm_r",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 9,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "leg_l",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 9,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "leg_r",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 9,
+            "immune_inside_vehicle": true
+          }
+        ]
+      },
+      {
+        "color": "red",
+        "convection_temperature_mod": 100,
+        "dangerous": true,
+        "effects": [
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 10,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "head",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 10,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "arm_l",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 10,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "arm_r",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 10,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "leg_l",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 10,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "leg_r",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 10,
+            "immune_inside_vehicle": true
+          }
+        ]
+      },
+      {
+        "color": "magenta",
+        "convection_temperature_mod": 110,
+        "dangerous": true,
+        "effects": [
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 11,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "head",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 11,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "arm_l",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 11,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "arm_r",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 11,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "leg_l",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 11,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "leg_r",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 11,
+            "immune_inside_vehicle": true
+          }
+        ]
+      },
+      {
+        "color": "magenta",
+        "convection_temperature_mod": 120,
+        "dangerous": true,
+        "effects": [
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 12,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "head",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 12,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "arm_l",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 12,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "arm_r",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 12,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "leg_l",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 12,
+            "immune_inside_vehicle": true
+          },
+          {
+            "effect_id": "effect_pyrokinetic_aura_damage",
+            "body_part": "leg_r",
+            "min_duration": "1 seconds",
+            "max_duration": "2 seconds",
+            "intensity": 12,
+            "immune_inside_vehicle": true
+          }
+        ]
+      }
+    ],
+    "immunity_data": { "flags": [ "HEAT_IMMUNE", "HEATSINK", "FIREPROOF", "FIREY" ] },
+    "decay_amount_factor": 5,
+    "has_fire": true,
+    "percent_spread": 10,
+    "priority": -1,
+    "half_life": "1 seconds",
+    "phase": "gas",
+    "display_field": true,
+    "looks_like": "fd_fire"
+  },
+  {
     "id": "fd_cold_air_nether_deep",
     "type": "field_type",
     "intensity_levels": [
@@ -152,6 +838,39 @@
     "phase": "gas"
   },
   {
+    "id": "fd_neutralizing_field",
+    "type": "field_type",
+    "intensity_levels": [
+      {
+        "name": "droning hum",
+        "effects": [
+          {
+            "effect_id": "effect_psi_null",
+            "intensity": 10,
+            "min_duration": "100 seconds",
+            "max_duration": "350 seconds",
+            "immune_inside_vehicle": false
+          },
+          {
+            "effect_id": "effect_psi_turn_off_powers",
+            "intensity": 1,
+            "min_duration": "1 seconds",
+            "max_duration": "1 seconds",
+            "immune_inside_vehicle": false
+          }
+        ]
+      },
+      { "//": "repeat last entry" },
+      { "//": "repeat last entry" }
+    ],
+    "decay_amount_factor": 5,
+    "gas_absorption_factor": 15,
+    "percent_spread": 5,
+    "priority": 8,
+    "half_life": "1 minutes",
+    "phase": "gas"
+  },
+  {
     "id": "fd_photokin_light_1",
     "type": "field_type",
     "intensity_levels": [
@@ -192,5 +911,43 @@
     "half_life": "30 minutes",
     "phase": "plasma",
     "display_field": true
+  },
+  {
+    "id": "fd_meadow_portal",
+    "type": "field_type",
+    "intensity_levels": [
+      {
+        "name": "swirling portal",
+        "color": "magenta",
+        "sym": "*",
+        "dangerous": true,
+        "monster_spawn_chance": 6000,
+        "monster_spawn_count": 1,
+        "monster_spawn_radius": 1,
+        "monster_spawn_group": "GROUP_ALIEN_MEADOW"
+      }
+    ],
+    "description_affix": "under",
+    "priority": 8,
+    "display_items": true,
+    "display_field": true,
+    "looks_like": "fd_fatigue"
+  },
+  {
+    "id": "fd_radiation_aura",
+    "type": "field_type",
+    "intensity_levels": [
+      {
+        "name": "glow",
+        "color": "light_cyan",
+        "sym": "*",
+        "dangerous": true,
+        "extra_radiation_min": 2,
+        "extra_radiation_max": 4
+      }
+    ],
+    "half_life": "2 seconds",
+    "linear_half_life": true,
+    "display_field": false
   }
 ]


### PR DESCRIPTION
## Description
- Backport missing fields
- Backport missing emits
- Gave `fd_pyrokinetic_aura` the `fd_fire` tile

## PR Type
- [x] Bug Fix
- [ ] Code Refactor
- [ ] Doc Changes
- [x] New Asset(s)
- [ ] New Feature(s)

## PR Size
- [ ] One-line
- [ ] Small
- [x] Medium
- [ ] Large

## Testing
<img width="824" height="721" alt="image" src="https://github.com/user-attachments/assets/e87d569f-d4bc-41b8-a758-cf5cae358546" />

## Notes
...