### PR TITLE
Fixed Refs to mon_zombie_fungus

### DIFF
--- a/monsters/monster_overrides.json
+++ b/monsters/monster_overrides.json
@@ -513,8 +513,8 @@
     "armor": { "electric": 3, "psi_telepathic_damage": 4 }
   },
   {
-    "id": "mon_zombie_fungus",
-    "copy-from": "mon_zombie_fungus",
+    "id": "mon_zombie_fungal",
+    "copy-from": "mon_zombie_fungal",
     "type": "MONSTER",
     "armor": { "bash": 3, "electric": 5, "psi_telepathic_damage": 6 }
   },


### PR DESCRIPTION
## Description
The override for `mon_zombie_fungus` was causing an error on load so I changed it to ref `mon_zombie_fungal`.

## PR Type
- [x] Bug Fix
- [ ] Code Refactor
- [ ] Doc Changes
- [ ] New Asset(s)
- [ ] New Feature(s)

## PR Size
- [x] One-line
- [ ] Small
- [ ] Medium
- [ ] Large

## Testing
Loaded a world with MoM-CTLG enabled.

## Notes
...