### PR TITLE
Fix Refs to EOC_PORTAL_NULL_AWAKENING

### DIFF
--- a/effectoncondition/eoc_misc.json
+++ b/effectoncondition/eoc_misc.json
@@ -331,5 +331,10 @@
     "type": "effect_on_condition",
     "id": "EOC_GIVE_PSION_MATRIX",
     "effect": [ { "u_spawn_item": "matrix_crystal_drained" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_DEBUG_BLANK",
+    "effect": [ { "u_message": "" } ]
   }
 ]

--- a/powers/clairsentience_eoc.json
+++ b/powers/clairsentience_eoc.json
@@ -21,7 +21,7 @@
     "id": "EOC_CLAIR_RAD_SENSE",
     "effect": [
       {
-        "run_eoc_selector": [ "EOC_CLAIR_RAD_SENSE_SELF", "EOC_CLAIR_RAD_SENSE_OUTSIDE", "EOC_PORTAL_NULL_AWAKENING" ],
+        "run_eoc_selector": [ "EOC_CLAIR_RAD_SENSE_SELF", "EOC_CLAIR_RAD_SENSE_OUTSIDE", "EOC_DEBUG_BLANK" ],
         "names": [ "Check yourself", "Check your surroundings", "Nevermind" ],
         "keys": [ "1", "2", "3" ],
         "descriptions": [

--- a/powers/pyrokinesis_eoc.json
+++ b/powers/pyrokinesis_eoc.json
@@ -11,7 +11,7 @@
           "EOC_PYROKIN_CAUTERIZE_LEFT_LEG",
           "EOC_PYROKIN_CAUTERIZE_RIGHT_LEG",
           "EOC_PYROKIN_CAUTERIZE_BODY",
-          "EOC_PORTAL_NULL_AWAKENING"
+          "EOC_DEBUG_BLANK"
         ],
         "names": [ "Left Arm", "Right Arm", "Head", "Left Leg", "Right Leg", "Torso", "Nevermind." ],
         "keys": [ "1", "2", "3", "4", "5", "6", "7" ],
@@ -577,7 +577,7 @@
           "EOC_SPELL_PYROKIN_SUMMON_HEAT_3",
           "EOC_SPELL_PYROKIN_SUMMON_HEAT_4",
           "EOC_SPELL_PYROKIN_BANISH_HEAT",
-          "EOC_PORTAL_NULL_AWAKENING"
+          "EOC_DEBUG_BLANK"
         ],
         "names": [
           "Minor thermogenesis",

--- a/powers/vitakinesis_eoc.json
+++ b/powers/vitakinesis_eoc.json
@@ -676,7 +676,7 @@
           "EOC_VITAKIN_BANISH_ILLNESS_NARCOLEPTIC",
           "EOC_VITAKIN_BANISH_ILLNESS_SEASONAL_ALLERGIES",
           "EOC_VITAKIN_BANISH_ILLNESS_SEASONAL_AFFECTIVE",
-          "EOC_PORTAL_NULL_AWAKENING"
+          "EOC_DEBUG_BLANK"
         ],
         "names": [
           "Purge Minor Ailments",


### PR DESCRIPTION
## Description
Added an EoC called `EOC_DEBUG_BLANK` to replace the functionality of `EOC_PORTAL_NULL_AWAKENING`.

## PR Type
- [x] Bug Fix
- [ ] Code Refactor
- [ ] Doc Changes
- [ ] New Asset(s)
- [ ] New Feature(s)

## PR Size
- [ ] One-line
- [x] Small
- [ ] Medium
- [ ] Large

## Testing
Opened a world a tested that `pyrokinetic_thermogenesis` works.

## Notes
Thanks to 'WartedEMS' for the report.
<img width="484" height="203" alt="image" src="https://github.com/user-attachments/assets/216a9bf5-3679-43d8-b5bb-368500683e74" />