### PR TITLE
Fix Psionic Shield Belts

### DIFF
--- a/items/armor/belt.json
+++ b/items/armor/belt.json
@@ -110,6 +110,7 @@
     "symbol": "[",
     "looks_like": "leather_belt",
     "color": "red",
+    "ammo": [ "battery" ],
     "material_thickness": 1.5,
     "pocket_data": [
       {

--- a/items/armor/belt.json
+++ b/items/armor/belt.json
@@ -12,6 +12,7 @@
     "symbol": "[",
     "looks_like": "leather_belt",
     "color": "yellow",
+    "ammo": [ "battery" ],
     "material_thickness": 1.5,
     "flags": [ "BELTED", "OVERSIZE", "NONCONDUCTIVE", "NO_REPAIR", "COMBAT_TOGGLEABLE" ],
     "use_action": [

--- a/items/armor/belt.json
+++ b/items/armor/belt.json
@@ -67,7 +67,7 @@
     "type": "TOOL_ARMOR",
     "name": { "str": "shield belt (active)", "str_pl": "shield belts (active)" },
     "copy-from": "psionic_shield_belt",
-    "power_draw": "150 W",
+    "power_draw": "1500 W",
     "revert_to": "psionic_shield_belt",
     "use_action": [
       {
@@ -161,7 +161,7 @@
     "type": "TOOL_ARMOR",
     "name": { "str": "suppression belt (active)", "str_pl": "suppression belts (active)" },
     "copy-from": "psionic_fire_shield_belt",
-    "power_draw": "50 W",
+    "power_draw": "500 W",
     "revert_to": "psionic_fire_shield_belt",
     "use_action": [
       {


### PR DESCRIPTION
## Description
Gave `psionic_shield_belt` and `psionic_fire_shield_belt` an 'ammo' field and fixed power consumption to be in line with TLG.

## PR Type
- [x] Bug Fix
- [ ] Code Refactor
- [ ] Doc Changes
- [ ] New Asset(s)
- [ ] New Feature(s)

## PR Size
- [x] One-line
- [ ] Small
- [ ] Medium
- [ ] Large

## Testing
Inserted a medium battery into the shield belt and it worked.

## Notes
...