### PR TITLE
Remove Autonote Feature From Map Extras

### DIFF
--- a/overmap/map_extras.json
+++ b/overmap/map_extras.json
@@ -7,7 +7,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_alien_grass" },
     "sym": "A",
     "color": "red",
-    "autonote": true
+    "autonote": false
   },
   {
     "id": "mx_alien_grass_2",
@@ -17,7 +17,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_alien_grass_2" },
     "sym": "A",
     "color": "magenta",
-    "autonote": true
+    "autonote": false
   },
   {
     "id": "mx_alien_grass_3",
@@ -27,7 +27,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_alien_grass_3" },
     "sym": "A",
     "color": "cyan",
-    "autonote": true
+    "autonote": false
   },
   {
     "id": "mx_alien_grass_4",
@@ -37,7 +37,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_alien_grass_4" },
     "sym": "A",
     "color": "yellow",
-    "autonote": true
+    "autonote": false
   },
   {
     "id": "mx_alien_grass_5",
@@ -47,7 +47,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_alien_grass_5" },
     "sym": "A",
     "color": "light_red",
-    "autonote": true
+    "autonote": false
   },
   {
     "id": "mx_alien_grove",
@@ -57,7 +57,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_alien_grove" },
     "sym": "F",
     "color": "magenta",
-    "autonote": true
+    "autonote": false
   },
   {
     "id": "mx_nether_pond",
@@ -67,7 +67,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nether_pond" },
     "sym": "O",
     "color": "dark_gray",
-    "autonote": true
+    "autonote": false
   },
   {
     "id": "mx_fear_hawk_copse",
@@ -76,7 +76,7 @@
     "description": "A suspicious copse of trees.",
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_trees_map" },
     "min_max_zlevel": [ 0, 0 ],
-    "autonote": true
+    "autonote": false
   },
   {
     "id": "mx_glass_and_crystal",
@@ -86,7 +86,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_glass_and_crystal" },
     "sym": "C",
     "color": "dark_gray",
-    "autonote": true
+    "autonote": false
   },
   {
     "id": "mx_phavian_science",
@@ -97,7 +97,7 @@
     "min_max_zlevel": [ -5, 0 ],
     "sym": "s",
     "color": "light_blue",
-    "autonote": true,
+    "autonote": false,
     "flags": [ "MAN_MADE" ]
   }
 ]


### PR DESCRIPTION
## Description
Set autonote field to false within all MoM-CTLG map extras to be in line with TLG's design.

## PR Type
- [x] Bug Fix
- [ ] Code Refactor
- [ ] Doc Changes
- [ ] New Asset(s)
- [ ] New Feature(s)

## PR Size
- [ ] One-line
- [x] Small
- [ ] Medium
- [ ] Large

## Testing
Loaded a world and spawned a map extra.
<img width="606" height="447" alt="image" src="https://github.com/user-attachments/assets/46c7ffec-167a-4505-8c7a-ae9e0e392c2a" />
<img width="558" height="407" alt="image" src="https://github.com/user-attachments/assets/76730031-66e9-41d1-bc82-b94666265eed" />

## Notes
Thanks to 'Xikorut' for the report.
<img width="615" height="534" alt="image" src="https://github.com/user-attachments/assets/7be3e590-e3c7-4399-86cc-7d01f3322f42" />
Thanks to 'Worm Girl' for the extra information.
<img width="579" height="207" alt="image" src="https://github.com/user-attachments/assets/134dad7d-2781-4584-8d48-77efc949c546" />