### PR TITLE
Fix Phavian Office Mapgen

### DIFF
--- a/mapgen/phavian_office.json
+++ b/mapgen/phavian_office.json
@@ -60,7 +60,7 @@
         "o": "f_bookcase",
         "t": "f_table"
       },
-      "vendingmachines": { "V": { "lootable": true } },
+      "vendingmachines": { "V": {  } },
       "toilets": { "T": {  } },
       "items": {
         "e": { "item": "SUS_fridge_breakroom", "chance": 55, "repeat": [ 2, 3 ] },
@@ -179,7 +179,7 @@
         "+": "t_door_c",
         "s": "t_soil"
       },
-      "vendingmachines": { "V": { "lootable": true } },
+      "vendingmachines": { "V": {  } },
       "toilets": { "T": {  } },
       "furniture": { "9": "f_metal_bench", "S": "f_sink", "J": "f_counter" },
       "place_nested": [


### PR DESCRIPTION
## Description
Removed 'lootable' field from 'vendingmachines' mapgen field.

## PR Type
- [x] Bug Fix
- [ ] Code Refactor
- [ ] Doc Changes
- [ ] New Asset(s)
- [ ] New Feature(s)

## PR Size
- [x] One-line
- [ ] Small
- [ ] Medium
- [ ] Large

## Testing
Loaded a test world with MoM-CTLG installed.

## Notes
...