### PR TITLE
Fix rot_spawn Def

### DIFF
--- a/items/comestibles.json
+++ b/items/comestibles.json
@@ -218,7 +218,8 @@
     "id": "egg_cockatrice",
     "name": { "str": "cockatrice egg" },
     "copy-from": "egg_chicken",
-    "rot_spawn": "GROUP_EGG_COCKATRICE"
+    "//": "Copied new rot_spawn chance from egg_chicken def",
+    "rot_spawn": { "group": "GROUP_EGG_COCKATRICE", "chance": 70 }
   },
   {
     "id": "black_nether_water",


### PR DESCRIPTION
## Description
Fixed the `rot_spawn` field in `egg_cockatrice`. Thanks to 'Jexyll' and @AerosolNinja for the report.

## PR Type
- [x] Bug Fix
- [ ] Code Refactor
- [ ] Doc Changes
- [ ] New Asset(s)
- [ ] New Feature(s)

## PR Size
- [x] One-line
- [ ] Small
- [ ] Medium
- [ ] Large

## Testing
World with MoM-CTLG installed starts as normal.

## Notes
<img width="621" height="303" alt="image" src="https://github.com/user-attachments/assets/06864472-5a89-4df9-8c9c-258f87c8335d" />