### PR TITLE
Fix u_query_tile Implementation

### DIFF
--- a/powers/teleportation_eoc.json
+++ b/powers/teleportation_eoc.json
@@ -49,17 +49,18 @@
                     "id": "EOC_TELEPORT_ITEM_APPORT_ITEM_QUALIFIES",
                     "effect": [
                       {
-                        "if": {
-                          "u_query_tile": "line_of_sight",
-                          "target_var": { "global_val": "teleporter_item_apport_location" },
-                          "range": {
-                            "math": [
-                              "min( ( ( (u_spell_level('teleport_item_apport') * 1.25) + 2) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling), 80)"
-                            ]
-                          },
-                          "z_level": true,
-                          "message": "Select apport location."
+                        "u_query_tile": "line_of_sight",
+                        "target_var": { "global_val": "teleporter_item_apport_location" },
+                        "range": {
+                          "math": [
+                            "min( ( ( (u_spell_level('teleport_item_apport') * 1.25) + 2) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling), 80)"
+                          ]
                         },
+                        "z_level": true,
+                        "message": "Select apport location."
+                      },
+                      {
+                        "if": { "math": [ "has_var(teleporter_item_apport_location)" ] },
                         "then": {
                           "if": {
                             "or": [


### PR DESCRIPTION
## Description
`u_query_tile` was changed to not return a value anymore so I had to change the condition to use `has_var()`.

## PR Type
- [x] Bug Fix
- [ ] Code Refactor
- [ ] Doc Changes
- [ ] New Asset(s)
- [ ] New Feature(s)

## PR Size
- [ ] One-line
- [x] Small
- [ ] Medium
- [ ] Large

## Testing
<img width="285" height="312" alt="image" src="https://github.com/user-attachments/assets/0a7a13a2-19e1-4a6a-8910-48b2eff11bfa" />
<img width="334" height="289" alt="image" src="https://github.com/user-attachments/assets/113932a5-7f7c-4d25-8573-94e00b033a57" />

## Notes
[TLG PR #1451](https://github.com/Cataclysm-TLG/Cataclysm-TLG/pull/1451)