### PR TITLE
Fix clair_craft_bonus

### DIFF
--- a/effects/effects_psionic.json
+++ b/effects/effects_psionic.json
@@ -1480,7 +1480,7 @@
         ]
       }
     ],
-    "flags": [ "MYOPIC", "CRAFT_IN_DARKNESS" ]
+    "flags": [ "MYOPIC", "BLIND_CRAFT" ]
   },
   {
     "type": "effect_type",


### PR DESCRIPTION
## Description
Add `BLIND_CRAFT` flag to `effect_clair_craft_bonus`.

## PR Type
- [x] Bug Fix
- [ ] Code Refactor
- [ ] Doc Changes
- [ ] New Asset(s)
- [ ] New Feature(s)

## PR Size
- [x] One-line
- [ ] Small
- [ ] Medium
- [ ] Large

## Testing
Player is able to craft in the dark with `clair_craft_bonus` active.

## Notes
[TLG PR #1450](https://github.com/Cataclysm-TLG/Cataclysm-TLG/pull/1450)