### PR TITLE
Fix mon_zombie_concentration_ender

### DIFF
--- a/monsters/monster_eoc_spells.json
+++ b/monsters/monster_eoc_spells.json
@@ -113,12 +113,18 @@
     "valid_targets": [ "hostile" ],
     "flags": [ "NO_PROJECTILE", "NO_EXPLOSION_SFX" ],
     "effect": "effect_on_condition",
-    "effect_str": "EOC_NULL_BREAK_CONCENTRATION",
+    "effect_str": "EOC_NULL_BREAK_CHECK_IF_CHAR",
     "shape": "blast",
     "max_level": 1,
     "min_damage": 1,
     "max_damage": 2,
     "min_range": 25
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_NULL_BREAK_CHECK_IF_CHAR",
+    "condition": "u_is_character",
+    "effect": { "run_eocs": "EOC_NULL_BREAK_CONCENTRATION" }
   },
   {
     "type": "effect_on_condition",


### PR DESCRIPTION
## Description
`mon_zombie_concentration_ender` was causing an error when casting it's power on non-player characters. I fixed this by adding the `EOC_NULL_BREAK_CHECK_IF_CHAR` EoC.

## PR Type
- [x] Bug Fix
- [ ] Code Refactor
- [ ] Doc Changes
- [ ] New Asset(s)
- [ ] New Feature(s)

## PR Size
- [ ] One-line
- [x] Small
- [ ] Medium
- [ ] Large

## Testing
Tested `mon_zombie_concentration_ender` against Colossal Slug (scenario from attached issue) and the player character.

## Notes
Issue: #60