### PR TITLE
Remove `mon_science_bot` From Monster Groups

### DIFF
--- a/monstergroups/monstergroups_new.json
+++ b/monstergroups/monstergroups_new.json
@@ -127,7 +127,6 @@
       { "monster": "mon_zombie_hazmat", "weight": 200 },
       { "monster": "mon_zombie_necro", "weight": 15, "cost_multiplier": 5 },
       { "monster": "mon_zombie_electric", "weight": 50, "cost_multiplier": 2 },
-      { "monster": "mon_science_bot", "weight": 80, "cost_multiplier": 5 },
       { "monster": "mon_secubot", "weight": 1, "cost_multiplier": 5 },
       { "monster": "mon_zombie", "weight": 100, "pack_size": [ 1, 3 ] },
       { "monster": "mon_zombie_fat", "weight": 20, "pack_size": [ 1, 3 ] },


### PR DESCRIPTION
## Description
Removed `mon_science_bot` from `monstergroups_new.json` as it was causing a JSON error on launch.

## PR Type
- [x] Bug Fix
- [ ] Code Refactor
- [ ] Doc Changes
- [ ] New Asset(s)
- [ ] New Feature(s)

## PR Size
- [x] One-line
- [ ] Small
- [ ] Medium
- [ ] Large

## Testing
Launched world with changes implemented and it worked without errors.

## Notes
Error:
```
 DEBUG : invalid monster type id "mon_science_bot"

 REPORTING FUNCTION : obj
 C++ SOURCE FILE    : D:\a\Cataclysm-TLG\Cataclysm-TLG\src\generic_factory.h
 LINE               : 490
 VERSION            : 2025-11-16-1450
```