### PR TITLE
Keeping pace with CTLG obsoletions

### DIFF
--- a/mapgen/nested/office_phavian_modular.json
+++ b/mapgen/nested/office_phavian_modular.json
@@ -778,9 +778,9 @@
       ],
       "palettes": [ "office_phavian_palette" ],
       "place_item": [
-        { "item": "escape_stone", "x": 3, "y": 4, "chance": 30 },
+        { "item": "pebble", "x": 3, "y": 4, "chance": 30 },
         { "item": "vortex_stone", "x": 4, "y": 4, "chance": 30 },
-        { "item": "calming_stone", "x": 0, "y": 4, "chance": 30 },
+        { "item": "pebble", "x": 0, "y": 4, "chance": 30 },
         { "item": "chaos_stone", "x": 7, "y": 6, "chance": 30 }
       ],
       "items": {
@@ -818,9 +818,9 @@
       ],
       "palettes": [ "office_phavian_palette" ],
       "place_item": [
-        { "item": "escape_stone", "x": 4, "y": 3, "chance": 30 },
+        { "item": "pebble", "x": 4, "y": 3, "chance": 30 },
         { "item": "vortex_stone", "x": 3, "y": 3, "chance": 30 },
-        { "item": "calming_stone", "x": 7, "y": 3, "chance": 30 },
+        { "item": "pebble", "x": 7, "y": 3, "chance": 30 },
         { "item": "chaos_stone", "x": 0, "y": 1, "chance": 30 }
       ],
       "items": {

--- a/monsters/monster_overrides.json
+++ b/monsters/monster_overrides.json
@@ -663,12 +663,6 @@
     "species": [ "ROBOT", "YRAX_CONSTRUCT" ]
   },
   {
-    "id": "mon_yrax_sphenocorona",
-    "copy-from": "mon_yrax_sphenocorona",
-    "type": "MONSTER",
-    "species": [ "ROBOT", "YRAX_CONSTRUCT" ]
-  },
-  {
     "id": "mon_zombie_master",
     "copy-from": "mon_zombie_master",
     "type": "MONSTER",

--- a/monsters/monster_overrides_tameable.json
+++ b/monsters/monster_overrides_tameable.json
@@ -70,16 +70,9 @@
     "extend": { "flags": [ "CANPLAY", "PET_MOUNTABLE" ] }
   },
   {
-    "id": "mon_fox_gray",
+    "id": "mon_fox",
     "type": "MONSTER",
-    "copy-from": "mon_fox_gray",
-    "name": { "str": "fox", "str_pl": "foxes" },
-    "extend": { "flags": [ "CANPLAY" ] }
-  },
-  {
-    "id": "mon_fox_red",
-    "type": "MONSTER",
-    "copy-from": "mon_fox_red",
+    "copy-from": "mon_fox",
     "name": { "str": "fox", "str_pl": "foxes" },
     "extend": { "flags": [ "CANPLAY" ] }
   },


### PR DESCRIPTION
Hi, and thanks for your work first of all. I play CTLG with MOM, and recent cleanups/migrations in CTLG caused some errors in MOM on worldgen. I fixed these for a clean start. Not really involved with CTLG development, but given a glance at recent commits over there, these seemed reasonable fixes to me. Feel free to decline if they are not.

- There are only foxes now, no red/gray difference
- Yrax Sphenocorona seems to have been removed
- Calming and Escape stones in Phavian offices are being migrated/removed

## Description
...

## PR Type
- [x] Bug Fix
- [ ] Code Refactor
- [ ] Doc Changes
- [ ] New Asset(s)
- [ ] New Feature(s)

## PR Size
- [ ] One-line
- [x] Small
- [ ] Medium
- [ ] Large

## Testing
Generated a new playthrough using these changes, no errors.

## Notes
...