### PR TITLE
Fix Steel Component Names

### DIFF
--- a/furniture_and_terrain/appliance_lighting.json
+++ b/furniture_and_terrain/appliance_lighting.json
@@ -16,7 +16,7 @@
     "looks_like": "atomic_lamp",
     "breaks_into": [
       { "item": "cable", "charges": [ 1, 4 ] },
-      { "item": "steel_chunk", "count": [ 0, 2 ] },
+      { "item": "steel_fragment", "count": [ 0, 2 ] },
       { "item": "scrap", "count": [ 1, 2 ] }
     ],
     "flags": [ "CIRCLE_LIGHT", "APPLIANCE", "ENABLED_DRAINS_EPOWER", "CTRL_ELECTRONIC" ],

--- a/recipes/armor.json
+++ b/recipes/armor.json
@@ -24,7 +24,7 @@
       [ [ "matrix_crystal_telepath_dust_refined", 6 ] ],
       [ [ "matrix_crystal_teleport_dust_refined", 2 ] ],
       [ [ "matrix_crystal_teleportation", 1 ] ],
-      [ [ "steel_chunk", 2 ], [ "steel_lump", 1 ] ]
+      [ [ "steel_fragment", 2 ], [ "steel_chunk", 1 ] ]
     ],
     "flags": [ "SECRET" ]
   },
@@ -54,7 +54,7 @@
       [ [ "psionic_serum_base", 2 ] ],
       [ [ "matrix_crystal_telepath_dust_refined", 6 ] ],
       [ [ "matrix_crystal_telepathy", 1 ] ],
-      [ [ "steel_chunk", 3 ], [ "steel_lump", 2 ] ]
+      [ [ "steel_fragment", 3 ], [ "steel_chunk", 2 ] ]
     ],
     "flags": [ "SECRET" ]
   }


### PR DESCRIPTION
## Description
The names of steel components (`steel_chunk`/`steel_lump`) were changed so this PR fixes any discrepancies.

## PR Type
- [x] Bug Fix
- [ ] Code Refactor
- [ ] Doc Changes
- [ ] New Asset(s)
- [ ] New Feature(s)

## PR Size
- [ ] One-line
- [x] Small
- [ ] Medium
- [ ] Large

## Testing
Loaded world and modified items were correct.
<img width="615" height="675" alt="image" src="https://github.com/user-attachments/assets/041624ab-0b77-49f3-bcc0-cf21cbc166fb" />

## Notes
Changes in accordance with https://github.com/Cataclysm-TLG/Cataclysm-TLG/pull/1780.