### PR TITLE
Added Remove Message to Oxygen Absorption

### DIFF
--- a/effects/effects_psionic.json
+++ b/effects/effects_psionic.json
@@ -158,6 +158,8 @@
     "//": "effect used as tracker",
     "name": [ "Oxygen Absorption" ],
     "desc": [ "You can absorb oxygen through your skin." ],
+    "apply_message": "",
+    "remove_message": "You feel your skin seal shut.",
     "rating": "good",
     "max_duration": "7 days"
   },


### PR DESCRIPTION
## Description
Oxygen absorption didn't have any message when you stopped concentrating; this PR fixes that.

## PR Type
- [x] Bug Fix
- [ ] Code Refactor
- [ ] Doc Changes
- [ ] New Asset(s)
- [ ] New Feature(s)

## PR Size
- [x] One-line
- [ ] Small
- [ ] Medium
- [ ] Large

## Testing
<img width="472" height="55" alt="image" src="https://github.com/user-attachments/assets/d233f4fd-b3ba-4d64-a424-eb72303d858e" />

## Notes
Originally reported by 'Mystic_Spider'
<img width="435" height="75" alt="image" src="https://github.com/user-attachments/assets/1b080b28-8e7e-486d-9e05-65347169b341" />