### PR TITLE
Backport Item Subtype Changes

### DIFF
--- a/items/ammo.json
+++ b/items/ammo.json
@@ -19,14 +19,15 @@
   },
   {
     "id": "mom_pulse_rifle_ammo",
-    "type": "AMMO",
+    "type": "ITEM",
+    "subtypes": ["AMMO"],
     "name": { "str_sp": "LV429 pulse shot" },
     "description": "A charge for the LV429.",
     "weight": "1 g",
     "volume": "1 ml",
     "price": "1 USD 60 cent",
     "price_postapoc": "8 USD",
-    "material": [ "superalloy", "steel" ],
+    "material": ["superalloy", "steel"],
     "symbol": "=",
     "color": "red",
     "count": 1,
@@ -35,10 +36,15 @@
     "range": 40,
     "dispersion": 0,
     "recoil": 0,
-    "damage": { "damage_type": "psi_photokinetic_damage", "amount": 55, "armor_penetration": 4 }
+    "damage": {
+      "damage_type": "psi_photokinetic_damage",
+      "amount": 55,
+      "armor_penetration": 4
+    }
   },
   {
-    "type": "AMMO",
+    "type": "ITEM",
+    "subtypes": ["AMMO"],
     "id": "psionic_charge_power",
     "category": "spare_parts",
     "price": "10 USD",
@@ -46,15 +52,16 @@
     "symbol": "=",
     "color": "white",
     "description": "Power charge for matrix technology.",
-    "flags": [ "TRADER_AVOID", "ZERO_WEIGHT" ],
+    "flags": ["TRADER_AVOID", "ZERO_WEIGHT"],
     "weight": "0 mg",
     "volume": "0 ml",
     "ammo_type": "psionic_charge_power",
-    "material": [ "nether_crystal" ],
+    "material": ["nether_crystal"],
     "count": 100
   },
   {
-    "type": "AMMO",
+    "type": "ITEM",
+    "subtypes": ["AMMO"],
     "id": "noetic_charge_power",
     "copy-from": "psionic_charge_power",
     "name": { "str_sp": "noetic energy" },

--- a/items/armor/belt.json
+++ b/items/armor/belt.json
@@ -1,20 +1,27 @@
 [
   {
     "id": "psionic_shield_belt",
-    "type": "TOOL_ARMOR",
+    "type": "ITEM",
+    "subtypes": ["TOOL", "ARMOR"],
     "name": { "str": "shield belt" },
     "description": "A simple synthetic fabric belt with a box to the right of the belt loop.  The box has a toggleable switch and a stylized shield with Ψ and the XEDRA logo inside it.",
     "weight": "350 g",
     "volume": "500 ml",
     "price": "100 USD",
     "price_postapoc": "50 USD",
-    "material": [ "nylon", "steel", "nether_crystal" ],
+    "material": ["nylon", "steel", "nether_crystal"],
     "symbol": "[",
     "looks_like": "leather_belt",
     "color": "yellow",
-    "tool_ammo": [ "battery" ],
+    "tool_ammo": ["battery"],
     "material_thickness": 1.5,
-    "flags": [ "BELTED", "OVERSIZE", "NONCONDUCTIVE", "NO_REPAIR", "COMBAT_TOGGLEABLE" ],
+    "flags": [
+      "BELTED",
+      "OVERSIZE",
+      "NONCONDUCTIVE",
+      "NO_REPAIR",
+      "COMBAT_TOGGLEABLE"
+    ],
     "use_action": [
       {
         "type": "transform",
@@ -31,7 +38,7 @@
       {
         "pocket_type": "MAGAZINE_WELL",
         "rigid": true,
-        "flag_restriction": [ "BATTERY_MEDIUM" ],
+        "flag_restriction": ["BATTERY_MEDIUM"],
         "default_magazine": "medium_battery_cell"
       }
     ],
@@ -39,8 +46,8 @@
       {
         "encumbrance": 2,
         "coverage": 50,
-        "covers": [ "torso" ],
-        "specifically_covers": [ "torso_waist" ],
+        "covers": ["torso"],
+        "specifically_covers": ["torso_waist"],
         "volume_encumber_modifier": 0.35
       }
     ],
@@ -51,7 +58,12 @@
           "condition": "ACTIVE",
           "name": "Active Shield Belt",
           "description": "The air around you has a faint shimmer.",
-          "ench_effects": [ { "effect": "effect_shield_belt_telekin_protection", "intensity": 1 } ],
+          "ench_effects": [
+            {
+              "effect": "effect_shield_belt_telekin_protection",
+              "intensity": 1
+            }
+          ],
           "incoming_damage_mod": [
             { "type": "cut", "add": -15 },
             { "type": "bash", "add": -8 },
@@ -64,8 +76,12 @@
   },
   {
     "id": "psionic_shield_belt_on",
-    "type": "TOOL_ARMOR",
-    "name": { "str": "shield belt (active)", "str_pl": "shield belts (active)" },
+    "type": "ITEM",
+    "subtypes": ["TOOL", "ARMOR"],
+    "name": {
+      "str": "shield belt (active)",
+      "str_pl": "shield belts (active)"
+    },
     "copy-from": "psionic_shield_belt",
     "power_draw": "1500 W",
     "revert_to": "psionic_shield_belt",
@@ -78,11 +94,12 @@
         "type": "transform"
       }
     ],
-    "extend": { "flags": [ "NO_TAKEOFF" ] }
+    "extend": { "flags": ["NO_TAKEOFF"] }
   },
   {
     "id": "psionic_shield_belt_broken",
-    "type": "TOOL_ARMOR",
+    "type": "ITEM",
+    "subtypes": ["TOOL", "ARMOR"],
     "name": { "str": "shield belt" },
     "copy-from": "psionic_shield_belt",
     "description": "A simple synthetic fabric belt with a box to the right of the belt loop.  The box has a toggleable switch and a stylized shield with Ψ and the XEDRA logo inside it.  It also has a large crack across it and rattles when moved.",
@@ -99,24 +116,25 @@
   },
   {
     "id": "psionic_fire_shield_belt",
-    "type": "TOOL_ARMOR",
+    "type": "ITEM",
+    "subtypes": ["TOOL", "ARMOR"],
     "name": { "str": "suppression belt" },
     "description": "A simple synthetic fabric belt with a box to the right of the belt loop.  The box has a toggleable switch and a stylized flame with a large circle and line superimposed over it and a Ψ behind the XEDRA logo inside it.",
     "weight": "350 g",
     "volume": "500 ml",
     "price": "100 USD",
     "price_postapoc": "50 USD",
-    "material": [ "nylon", "steel", "nether_crystal" ],
+    "material": ["nylon", "steel", "nether_crystal"],
     "symbol": "[",
     "looks_like": "leather_belt",
     "color": "red",
-    "tool_ammo": [ "battery" ],
+    "tool_ammo": ["battery"],
     "material_thickness": 1.5,
     "pocket_data": [
       {
         "pocket_type": "MAGAZINE_WELL",
         "rigid": true,
-        "flag_restriction": [ "BATTERY_MEDIUM" ],
+        "flag_restriction": ["BATTERY_MEDIUM"],
         "default_magazine": "medium_battery_electronoetic"
       }
     ],
@@ -132,13 +150,19 @@
         "menu_text": "Flip the switch"
       }
     ],
-    "flags": [ "BELTED", "OVERSIZE", "NONCONDUCTIVE", "NO_REPAIR", "COMBAT_TOGGLEABLE" ],
+    "flags": [
+      "BELTED",
+      "OVERSIZE",
+      "NONCONDUCTIVE",
+      "NO_REPAIR",
+      "COMBAT_TOGGLEABLE"
+    ],
     "armor": [
       {
         "encumbrance": 2,
         "coverage": 50,
-        "covers": [ "torso" ],
-        "specifically_covers": [ "torso_waist" ],
+        "covers": ["torso"],
+        "specifically_covers": ["torso_waist"],
         "volume_encumber_modifier": 0.35
       }
     ],
@@ -149,17 +173,26 @@
           "condition": "ACTIVE",
           "name": "Active Suppression Belt",
           "description": "The air around you feels cool.",
-          "incoming_damage_mod": [ { "type": "heat", "multiply": -1 } ],
-          "values": [ { "value": "CLIMATE_CONTROL_CHILL", "add": 1000 } ],
-          "ench_effects": [ { "effect": "effect_suppression_belt_fire_protection", "intensity": 1 } ]
+          "incoming_damage_mod": [{ "type": "heat", "multiply": -1 }],
+          "values": [{ "value": "CLIMATE_CONTROL_CHILL", "add": 1000 }],
+          "ench_effects": [
+            {
+              "effect": "effect_suppression_belt_fire_protection",
+              "intensity": 1
+            }
+          ]
         }
       ]
     }
   },
   {
     "id": "psionic_fire_shield_belt_on",
-    "type": "TOOL_ARMOR",
-    "name": { "str": "suppression belt (active)", "str_pl": "suppression belts (active)" },
+    "type": "ITEM",
+    "subtypes": ["TOOL", "ARMOR"],
+    "name": {
+      "str": "suppression belt (active)",
+      "str_pl": "suppression belts (active)"
+    },
     "copy-from": "psionic_fire_shield_belt",
     "power_draw": "500 W",
     "revert_to": "psionic_fire_shield_belt",
@@ -172,11 +205,12 @@
         "type": "transform"
       }
     ],
-    "extend": { "flags": [ "NO_TAKEOFF" ] }
+    "extend": { "flags": ["NO_TAKEOFF"] }
   },
   {
     "id": "psionic_fire_shield_belt_broken",
-    "type": "TOOL_ARMOR",
+    "type": "ITEM",
+    "subtypes": ["TOOL", "ARMOR"],
     "copy-from": "psionic_fire_shield_belt",
     "name": { "str": "suppression belt" },
     "description": "A simple synthetic fabric belt with a box to the right of the belt loop.  The box has a toggleable switch and a stylized flame with a large circle and line superimposed over it and a Ψ behind the XEDRA logo inside it.  It also has a large crack across it and rattles when moved.",
@@ -194,7 +228,7 @@
       {
         "pocket_type": "MAGAZINE_WELL",
         "rigid": true,
-        "flag_restriction": [ "BATTERY_MEDIUM" ],
+        "flag_restriction": ["BATTERY_MEDIUM"],
         "default_magazine": "medium_battery_electronoetic"
       }
     ]

--- a/items/armor/head.json
+++ b/items/armor/head.json
@@ -1,54 +1,97 @@
 [
   {
     "id": "psionic_anchoring_crown",
-    "type": "ARMOR",
+    "type": "ITEM",
+    "subtypes": ["ARMOR"],
     "name": { "str": "anchoring crown" },
     "description": "A thin steel circlet studded with chunks of matrix crystal.  Your skin prickles slightly where the crown touches it.",
     "weight": "80 g",
     "volume": "100 ml",
     "price": "50 USD",
     "price_postapoc": "25 cent",
-    "material": [ { "type": "steel", "portion": 9 }, { "type": "nether_crystal" } ],
+    "material": [
+      { "type": "steel", "portion": 9 },
+      { "type": "nether_crystal" }
+    ],
     "looks_like": "crown_golden",
     "symbol": "[",
     "color": "blue",
     "material_thickness": 1,
-    "flags": [ "DIMENSIONAL_ANCHOR", "PADDED" ],
-    "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "mutations": [ "ANCHORCROWN_NOSPELL" ] } ] },
-    "armor": [ { "encumbrance": 1, "coverage": 20, "covers": [ "head" ], "specifically_covers": [ "head_crown" ] } ]
+    "flags": ["DIMENSIONAL_ANCHOR", "PADDED"],
+    "relic_data": {
+      "passive_effects": [
+        {
+          "has": "WORN",
+          "condition": "ALWAYS",
+          "mutations": ["ANCHORCROWN_NOSPELL"]
+        }
+      ]
+    },
+    "armor": [
+      {
+        "encumbrance": 1,
+        "coverage": 20,
+        "covers": ["head"],
+        "specifically_covers": ["head_crown"]
+      }
+    ]
   },
   {
     "id": "psionic_telepathic_dampener",
-    "type": "ARMOR",
+    "type": "ITEM",
+    "subtypes": ["ARMOR"],
     "name": { "str": "telepathic dampener" },
     "description": "A steel skullcap with a matrix crystal at its crown.  It looks ridiculous, but the documents you read said it would protect you from telepathic attack.",
     "weight": "767 g",
     "volume": "2 L",
     "price": "30 USD",
     "price_postapoc": "25 cent",
-    "material": [ { "type": "steel", "portion": 12 }, { "type": "nether_crystal" } ],
+    "material": [
+      { "type": "steel", "portion": 12 },
+      { "type": "nether_crystal" }
+    ],
     "looks_like": "miner_hat",
     "symbol": "[",
     "color": "white",
     "material_thickness": 0.33,
-    "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "mutations": [ "TELEPATHICDAMPENER_SHIELD" ] } ] },
+    "relic_data": {
+      "passive_effects": [
+        {
+          "has": "WORN",
+          "condition": "ALWAYS",
+          "mutations": ["TELEPATHICDAMPENER_SHIELD"]
+        }
+      ]
+    },
     "armor": [
-      { "encumbrance": 4, "coverage": 100, "covers": [ "head" ], "specifically_covers": [ "head_crown", "head_forehead" ] }
+      {
+        "encumbrance": 4,
+        "coverage": 100,
+        "covers": ["head"],
+        "specifically_covers": ["head_crown", "head_forehead"]
+      }
     ],
-    "flags": [ "PADDED", "PORTAL_PROOF" ]
+    "flags": ["PADDED", "PORTAL_PROOF"]
   },
   {
     "id": "psionic_mindsight_glasses",
-    "type": "TOOL_ARMOR",
+    "type": "ITEM",
+    "subtypes": ["TOOL", "ARMOR"],
     "category": "clothing",
     "looks_like": "ar_glasses_advanced",
-    "name": { "str": "QD944-P 'Mindsight' glasses", "str_pl": "sets of QD944-P 'Mindsight' glasses" },
+    "name": {
+      "str": "QD944-P 'Mindsight' glasses",
+      "str_pl": "sets of QD944-P 'Mindsight' glasses"
+    },
     "description": "A set of AR-looking glasses.  The code \"QD944-P\" is printed in small letters on the temples.",
     "weight": "170 g",
     "volume": "750 ml",
     "price": "30 kUSD",
     "price_postapoc": "400 USD",
-    "material": [ { "type": "plastic", "portion": 12 }, { "type": "nether_crystal" } ],
+    "material": [
+      { "type": "plastic", "portion": 12 },
+      { "type": "nether_crystal" }
+    ],
     "symbol": "[",
     "color": "white",
     "tool_ammo": "battery",
@@ -65,14 +108,21 @@
       {
         "pocket_type": "MAGAZINE_WELL",
         "rigid": true,
-        "flag_restriction": [ "BATTERY_LIGHT", "BATTERY_ULTRA_LIGHT" ],
+        "flag_restriction": ["BATTERY_LIGHT", "BATTERY_ULTRA_LIGHT"],
         "default_magazine": "light_battery_electronoetic"
       }
     ],
-    "armor": [ { "encumbrance": 4, "coverage": 100, "covers": [ "eyes" ] } ],
+    "armor": [{ "encumbrance": 4, "coverage": 100, "covers": ["eyes"] }],
     "material_thickness": 1,
     "environmental_protection": 1,
-    "flags": [ "OUTER", "FRAGILE", "SUN_GLASSES", "WATER_BREAK", "PADDED", "ELECTRONIC" ],
+    "flags": [
+      "OUTER",
+      "FRAGILE",
+      "SUN_GLASSES",
+      "WATER_BREAK",
+      "PADDED",
+      "ELECTRONIC"
+    ],
     "relic_data": {
       "passive_effects": [
         {
@@ -82,7 +132,14 @@
             {
               "condition": { "test_eoc": "EOC_CONDITION_HAS_MIND" },
               "distance": 20,
-              "descriptions": [ { "id": "moving_creature", "symbol": "?", "color": "c_white", "text": "You sense something moving here." } ]
+              "descriptions": [
+                {
+                  "id": "moving_creature",
+                  "symbol": "?",
+                  "color": "c_white",
+                  "text": "You sense something moving here."
+                }
+              ]
             }
           ]
         }
@@ -91,10 +148,14 @@
   },
   {
     "id": "psionic_mindsight_glasses_on",
-    "type": "TOOL_ARMOR",
+    "type": "ITEM",
+    "subtypes": ["TOOL", "ARMOR"],
     "category": "clothing",
     "copy-from": "psionic_mindsight_glasses",
-    "name": { "str": "QD944-P 'Mindsight' glasses (on)", "str_pl": "sets of QD944-P 'Mindsight' glasses (on)" },
+    "name": {
+      "str": "QD944-P 'Mindsight' glasses (on)",
+      "str_pl": "sets of QD944-P 'Mindsight' glasses (on)"
+    },
     "description": "A set of AR-looking glasses.  The code \"QD944-P\" is printed in small letters on the temples.  They are currently active.",
     "use_action": {
       "ammo_scale": 0,

--- a/items/armor/overrides.json
+++ b/items/armor/overrides.json
@@ -2,17 +2,35 @@
   {
     "id": "dimensional_anchor",
     "copy-from": "dimensional_anchor",
-    "type": "TOOL_ARMOR",
+    "type": "ITEM",
+    "subtypes": ["TOOL", "ARMOR"],
     "category": "clothing",
     "name": { "str": "5-point anchor" },
-    "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ACTIVE", "mutations": [ "ANCHORCROWN_NOSPELL" ] } ] }
+    "relic_data": {
+      "passive_effects": [
+        {
+          "has": "WORN",
+          "condition": "ACTIVE",
+          "mutations": ["ANCHORCROWN_NOSPELL"]
+        }
+      ]
+    }
   },
   {
     "id": "dimensional_anchor_on",
     "copy-from": "dimensional_anchor_on",
-    "type": "TOOL_ARMOR",
+    "type": "ITEM",
+    "subtypes": ["TOOL", "ARMOR"],
     "category": "clothing",
     "name": { "str": "5-point anchor (on)", "str_pl": "5-point anchors (on)" },
-    "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ACTIVE", "mutations": [ "ANCHORCROWN_NOSPELL" ] } ] }
+    "relic_data": {
+      "passive_effects": [
+        {
+          "has": "WORN",
+          "condition": "ACTIVE",
+          "mutations": ["ANCHORCROWN_NOSPELL"]
+        }
+      ]
+    }
   }
 ]

--- a/items/batteries.json
+++ b/items/batteries.json
@@ -1,9 +1,13 @@
 [
   {
     "id": "light_battery_electronoetic",
-    "type": "MAGAZINE",
+    "type": "ITEM",
+    "subtypes": ["MAGAZINE"],
     "category": "tool_magazine",
-    "name": { "str": "light electronoetic battery", "str_pl": "light electronoetic batteries" },
+    "name": {
+      "str": "light electronoetic battery",
+      "str_pl": "light electronoetic batteries"
+    },
     "description": "A light battery but with the casing devoid of branding or symbols other than a plus and minus on opposite ends.  It's surprisingly heavy.",
     "weight": "20 g",
     "volume": "8 ml",
@@ -17,28 +21,48 @@
     ],
     "symbol": "=",
     "color": "cyan",
-    "ammo_type": [ "battery" ],
+    "ammo_type": ["battery"],
     "//": "Capacity 3x normal",
     "capacity": 48,
     "looks_like": "battery",
-    "flags": [ "NO_SALVAGE", "NO_UNLOAD", "NO_RELOAD", "BATTERY_LIGHT" ],
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 48 } } ]
+    "flags": ["NO_SALVAGE", "NO_UNLOAD", "NO_RELOAD", "BATTERY_LIGHT"],
+    "pocket_data": [
+      {
+        "pocket_type": "MAGAZINE",
+        "rigid": true,
+        "ammo_restriction": { "battery": 48 }
+      }
+    ]
   },
   {
     "id": "light_battery_electronoetic_refined",
     "copy-from": "light_battery_electronoetic",
-    "type": "MAGAZINE",
+    "type": "ITEM",
+    "subtypes": ["MAGAZINE"],
     "category": "tool_magazine",
-    "name": { "str": "light refined electronoetic battery", "str_pl": "light refined electronoetic batteries" },
+    "name": {
+      "str": "light refined electronoetic battery",
+      "str_pl": "light refined electronoetic batteries"
+    },
     "//": "Capacity 8x normal",
     "capacity": 128,
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 128 } } ]
+    "pocket_data": [
+      {
+        "pocket_type": "MAGAZINE",
+        "rigid": true,
+        "ammo_restriction": { "battery": 128 }
+      }
+    ]
   },
   {
     "id": "medium_battery_electronoetic",
-    "type": "MAGAZINE",
+    "type": "ITEM",
+    "subtypes": ["MAGAZINE"],
     "category": "tool_magazine",
-    "name": { "str": "medium electronoetic battery", "str_pl": "medium electronoetic batteries" },
+    "name": {
+      "str": "medium electronoetic battery",
+      "str_pl": "medium electronoetic batteries"
+    },
     "description": "A medium battery but with the casing devoid of branding or symbols other than a plus and minus on opposite ends.  It's surprisingly heavy.",
     "weight": "100 g",
     "volume": "17 ml",
@@ -52,28 +76,48 @@
     ],
     "symbol": "=",
     "color": "cyan",
-    "ammo_type": [ "battery" ],
+    "ammo_type": ["battery"],
     "looks_like": "battery",
-    "flags": [ "NO_SALVAGE", "NO_UNLOAD", "NO_RELOAD", "BATTERY_MEDIUM" ],
+    "flags": ["NO_SALVAGE", "NO_UNLOAD", "NO_RELOAD", "BATTERY_MEDIUM"],
     "//": "Capacity 3x normal",
     "capacity": 168,
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 168 } } ]
+    "pocket_data": [
+      {
+        "pocket_type": "MAGAZINE",
+        "rigid": true,
+        "ammo_restriction": { "battery": 168 }
+      }
+    ]
   },
   {
     "id": "medium_battery_electronoetic_refined",
     "copy-from": "medium_battery_electronoetic",
-    "type": "MAGAZINE",
+    "type": "ITEM",
+    "subtypes": ["MAGAZINE"],
     "category": "tool_magazine",
-    "name": { "str": "medium refined electronoetic battery", "str_pl": "medium refined electronoetic batteries" },
+    "name": {
+      "str": "medium refined electronoetic battery",
+      "str_pl": "medium refined electronoetic batteries"
+    },
     "//": "Capacity 8x normal",
     "capacity": 448,
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 448 } } ]
+    "pocket_data": [
+      {
+        "pocket_type": "MAGAZINE",
+        "rigid": true,
+        "ammo_restriction": { "battery": 448 }
+      }
+    ]
   },
   {
     "id": "heavy_battery_electronoetic",
-    "type": "MAGAZINE",
+    "type": "ITEM",
+    "subtypes": ["MAGAZINE"],
     "category": "tool_magazine",
-    "name": { "str": "electronoetic tool battery", "str_pl": "electronoetic tool batteries" },
+    "name": {
+      "str": "electronoetic tool battery",
+      "str_pl": "electronoetic tool batteries"
+    },
     "description": "A battery cell, compatible with all kinds of industrial-grade equipment and portable tools, but with the casing devoid of branding or symbols other than a plus and minus on opposite ends.  It's surprisingly heavy.",
     "weight": "400 g",
     "volume": "382 ml",
@@ -88,21 +132,37 @@
     ],
     "symbol": "=",
     "color": "cyan",
-    "ammo_type": [ "battery" ],
+    "ammo_type": ["battery"],
     "//": "Capacity 3x normal",
     "capacity": 777,
     "looks_like": "battery",
-    "flags": [ "NO_SALVAGE", "NO_UNLOAD", "NO_RELOAD", "BATTERY_HEAVY" ],
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 777 } } ]
+    "flags": ["NO_SALVAGE", "NO_UNLOAD", "NO_RELOAD", "BATTERY_HEAVY"],
+    "pocket_data": [
+      {
+        "pocket_type": "MAGAZINE",
+        "rigid": true,
+        "ammo_restriction": { "battery": 777 }
+      }
+    ]
   },
   {
     "id": "heavy_battery_electronoetic_refined",
     "copy-from": "medium_battery_electronoetic",
-    "type": "MAGAZINE",
+    "type": "ITEM",
+    "subtypes": ["MAGAZINE"],
     "category": "tool_magazine",
-    "name": { "str": "refined electronoetic tool battery", "str_pl": "refined electronoetic tool batteries" },
+    "name": {
+      "str": "refined electronoetic tool battery",
+      "str_pl": "refined electronoetic tool batteries"
+    },
     "//": "Capacity 8x normal",
     "capacity": 2072,
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 2072 } } ]
+    "pocket_data": [
+      {
+        "pocket_type": "MAGAZINE",
+        "rigid": true,
+        "ammo_restriction": { "battery": 2072 }
+      }
+    ]
   }
 ]

--- a/items/books.json
+++ b/items/books.json
@@ -1,16 +1,20 @@
 [
   {
     "id": "manual_meditation",
-    "type": "BOOK",
+    "type": "ITEM",
+    "subtypes": ["BOOK"],
     "category": "manuals",
-    "name": { "str": "Meditation and You", "str_pl": "copies of Meditation and You" },
+    "name": {
+      "str": "Meditation and You",
+      "str_pl": "copies of Meditation and You"
+    },
     "description": "A description of simple meditation and breathing techniques, intended for a beginner.",
     "weight": "1454 g",
     "volume": "1250 ml",
     "price": "25 USD",
     "price_postapoc": "1 USD 50 cent",
     "melee_damage": { "bash": 3 },
-    "material": [ "paper" ],
+    "material": ["paper"],
     "symbol": "?",
     "looks_like": "book_nonf_hard_psych_moodalm",
     "color": "white",
@@ -23,7 +27,10 @@
     "variants": [
       {
         "id": "manual_meditation_1",
-        "name": { "str": "Zen Mind, Beginner's Mind", "str_pl": "copies of Zen Mind, Beginner's Mind" },
+        "name": {
+          "str": "Zen Mind, Beginner's Mind",
+          "str_pl": "copies of Zen Mind, Beginner's Mind"
+        },
         "description": "This is a transcription of lectures given by Suzuki Shunryū, a Buddhist monk who founded the first Zen Buddhist monastery in the United States, containing discussion about Zen meditation and practice.",
         "weight": 1
       },
@@ -58,9 +65,13 @@
   },
   {
     "id": "manual_meditation_int",
-    "type": "BOOK",
+    "type": "ITEM",
+    "subtypes": ["BOOK"],
     "category": "manuals",
-    "name": { "str": "Secrets of the Zen Masters", "str_pl": "copies of Secrets of the Zen Masters" },
+    "name": {
+      "str": "Secrets of the Zen Masters",
+      "str_pl": "copies of Secrets of the Zen Masters"
+    },
     "description": "This book purports to contain hidden tips that will make you serene and calm in the face of the most grievous calamities.  Cataclysms, one might say.",
     "copy-from": "manual_meditation",
     "//": "Advanced meditation is controversial but I have to make the distinction somewhere.",
@@ -101,9 +112,13 @@
   },
   {
     "id": "manual_psionics_advan",
-    "type": "BOOK",
+    "type": "ITEM",
+    "subtypes": ["BOOK"],
     "category": "manuals",
-    "name": { "str": "Lab Journal-Otomo", "str_pl": "copies of Lab Journal-Otomo" },
+    "name": {
+      "str": "Lab Journal-Otomo",
+      "str_pl": "copies of Lab Journal-Otomo"
+    },
     "description": "This notebook is mostly a series of fanciful speculations about something the author alternately calls \"Matrix Mechanics,\", \"Dimensional Metaphysics,\" or \"Netherium Mathematics,\" sometimes using more than one in the same sentence.  Most of it is incoherent, but there is some experimental data about \"Conscious redirection of nether energy\" that catches your eye.",
     "copy-from": "recipe_lab_cvd",
     "read_skill": "metaphysics",
@@ -115,9 +130,13 @@
   },
   {
     "id": "phavian_report_psionic_drain",
-    "type": "BOOK",
+    "type": "ITEM",
+    "subtypes": ["BOOK"],
     "category": "manuals",
-    "name": { "str": "Report: Channeling Protocol PGS38", "str_pl": "copies of Report: Channeling Protocol PGS38" },
+    "name": {
+      "str": "Report: Channeling Protocol PGS38",
+      "str_pl": "copies of Report: Channeling Protocol PGS38"
+    },
     "description": "A formal report on a process to reduce the unpredictable effects of long-term psionic use.  It describes a special meditation technique, performed with the aid of a matrix crystal, though it does warn that the process: \"puts extreme stress on the focus object.  Further refinement is required.\"",
     "copy-from": "recipe_lab_elec",
     "read_skill": "metaphysics",
@@ -129,7 +148,8 @@
   },
   {
     "id": "manual_psionic_ritual",
-    "type": "BOOK",
+    "type": "ITEM",
+    "subtypes": ["BOOK"],
     "category": "manuals",
     "name": {
       "str": "Training Manual: Method of Loci and Dimensional Metaphysics",
@@ -146,7 +166,8 @@
   },
   {
     "id": "phavian_psionic_martial_power_book",
-    "type": "BOOK",
+    "type": "ITEM",
+    "subtypes": ["BOOK"],
     "category": "manuals",
     "name": {
       "str": "Training Manual: VERDANT HAND Combat Protocols",
@@ -163,9 +184,13 @@
   },
   {
     "id": "phavian_psionic_teleportation_combat_book",
-    "type": "BOOK",
+    "type": "ITEM",
+    "subtypes": ["BOOK"],
     "category": "manuals",
-    "name": { "str": "Proposal: TURQUOISE KEYSTONE", "str_pl": "copies of Proposal: TURQUOISE KEYSTONE" },
+    "name": {
+      "str": "Proposal: TURQUOISE KEYSTONE",
+      "str_pl": "copies of Proposal: TURQUOISE KEYSTONE"
+    },
     "description": "A formal report with a mostly-blank cover page, stamped with the Project PHAVIAN logo at the top and a red \"TURQUOISE KEYSTONE - EYES ONLY\" centered underneath.  Skimming through it, you see a lot of very worrying phrases in light of recent events, like \"…the sudden but so-far unexplained increase in our mathematicians' prowess…\" or \"…E71 is now capable of passing through two meters of solid matter.\"  The main topic of the document seems to be using teleportation (\"LOST RAIN\", as the report calls it) in combat.  By lengthening the space between the teleporter and their target to build up momentum on their strikes, warping space to make near-misses turn into hits, or teleporting fractions of a meter to avoid incoming attacks or put themselves in a better position to make strikes, the TURQUOISE KEYSTONE practitioner can vastly increase their prowess in close-quarters combat.  Written at the bottom of the last page is, \"We had better test this soon--I think we're going to need it.\"",
     "copy-from": "recipe_lab_elec",
     "read_skill": "metaphysics",
@@ -177,9 +202,13 @@
   },
   {
     "id": "phavian_psionic_telepathic_mental_engineering_book",
-    "type": "BOOK",
+    "type": "ITEM",
+    "subtypes": ["BOOK"],
     "category": "manuals",
-    "name": { "str": "Lab Report: PATIENT MOSAIC process", "str_pl": "copies of Lab Report: PATIENT MOSAIC process" },
+    "name": {
+      "str": "Lab Report: PATIENT MOSAIC process",
+      "str_pl": "copies of Lab Report: PATIENT MOSAIC process"
+    },
     "description": "A thick lab report with a mostly-blank cover page, stamped with the Project PHAVIAN logo at the top and a red \"PATIENT MOSAIC - EYES ONLY\" centered underneath.  According to the summary, the report details how a powerful GRAY DAWN participant may use a specifically attuned focusing tool to allow themselves to induce permanent changes in their personality and other segments of their brain.  The report details little success in GRAY DAWN participant applying this process to others.",
     "copy-from": "recipe_lab_elec",
     "read_skill": "metaphysics",

--- a/items/chemicals.json
+++ b/items/chemicals.json
@@ -1,11 +1,12 @@
 [
   {
     "id": "psionic_serum_base",
-    "type": "COMESTIBLE",
+    "type": "ITEM",
+    "subtypes": ["COMESTIBLE"],
     "comestible_type": "DRINK",
     "name": { "str_sp": "psychoreactive catalyst" },
     "description": "A thick liquid, mixed with ground matrix crystal and ready to be catalyzed.  In total darkness, it glows very faintly.",
-    "material": [ "alien_liquid", "nether_crystal", "water" ],
+    "material": ["alien_liquid", "nether_crystal", "water"],
     "weight": "30 g",
     "volume": "25 ml",
     "charges": 1,
@@ -13,10 +14,10 @@
     "price": "10 cent",
     "price_postapoc": "1 cent",
     "container": "flask_glass",
-    "flags": [ "TRADER_AVOID" ],
+    "flags": ["TRADER_AVOID"],
     "symbol": "~",
     "color": "black",
     "freezing_point": -8,
-    "use_action": [ "POISON" ]
+    "use_action": ["POISON"]
   }
 ]

--- a/items/comestibles.json
+++ b/items/comestibles.json
@@ -1,11 +1,12 @@
 [
   {
     "id": "matrix_crystal_biokin_dust_potion",
-    "type": "COMESTIBLE",
+    "type": "ITEM",
+    "subtypes": ["COMESTIBLE"],
     "comestible_type": "DRINK",
     "name": { "str_sp": "pink crystalline elixir" },
     "description": "Refined matrix crystal mixed directly into water.  The liquid has a faint pink glow.",
-    "material": [ "water" ],
+    "material": ["water"],
     "weight": "255 g",
     "volume": "250 ml",
     "charges": 1,
@@ -18,16 +19,17 @@
     "sealed": false,
     "quench": 50,
     "ammo_data": { "ammo_type": "water" },
-    "flags": [ "EATEN_COLD", "NUTRIENT_OVERRIDE", "NO_AUTO_CONSUME" ],
-    "consumption_effect_on_conditions": [ "EOC_BIOKIN_POTION" ]
+    "flags": ["EATEN_COLD", "NUTRIENT_OVERRIDE", "NO_AUTO_CONSUME"],
+    "consumption_effect_on_conditions": ["EOC_BIOKIN_POTION"]
   },
   {
     "id": "matrix_crystal_clair_dust_potion",
-    "type": "COMESTIBLE",
+    "type": "ITEM",
+    "subtypes": ["COMESTIBLE"],
     "comestible_type": "DRINK",
     "name": { "str_sp": "gray crystalline elixir" },
     "description": "Refined matrix crystal mixed directly into water.  The liquid has a faint grayish glow.",
-    "material": [ "water" ],
+    "material": ["water"],
     "weight": "255 g",
     "volume": "250 ml",
     "charges": 1,
@@ -40,16 +42,17 @@
     "sealed": false,
     "quench": 50,
     "ammo_data": { "ammo_type": "water" },
-    "flags": [ "EATEN_COLD", "NUTRIENT_OVERRIDE", "NO_AUTO_CONSUME" ],
-    "consumption_effect_on_conditions": [ "EOC_CLAIR_POTION" ]
+    "flags": ["EATEN_COLD", "NUTRIENT_OVERRIDE", "NO_AUTO_CONSUME"],
+    "consumption_effect_on_conditions": ["EOC_CLAIR_POTION"]
   },
   {
     "id": "matrix_crystal_electrokin_dust_potion",
-    "type": "COMESTIBLE",
+    "type": "ITEM",
+    "subtypes": ["COMESTIBLE"],
     "comestible_type": "DRINK",
     "name": { "str_sp": "cyan crystalline elixir" },
     "description": "Refined matrix crystal mixed directly into water.  The liquid has a faint sky-blue glow.",
-    "material": [ "water" ],
+    "material": ["water"],
     "weight": "255 g",
     "volume": "250 ml",
     "charges": 1,
@@ -62,16 +65,17 @@
     "sealed": false,
     "quench": 50,
     "ammo_data": { "ammo_type": "water" },
-    "flags": [ "EATEN_COLD", "NUTRIENT_OVERRIDE", "NO_AUTO_CONSUME" ],
-    "consumption_effect_on_conditions": [ "EOC_ELECTROKIN_POTION" ]
+    "flags": ["EATEN_COLD", "NUTRIENT_OVERRIDE", "NO_AUTO_CONSUME"],
+    "consumption_effect_on_conditions": ["EOC_ELECTROKIN_POTION"]
   },
   {
     "id": "matrix_crystal_photokin_dust_potion",
-    "type": "COMESTIBLE",
+    "type": "ITEM",
+    "subtypes": ["COMESTIBLE"],
     "comestible_type": "DRINK",
     "name": { "str_sp": "golden crystalline elixir" },
     "description": "Refined matrix crystal mixed directly into water.  The liquid has a faint golden glow.",
-    "material": [ "water" ],
+    "material": ["water"],
     "weight": "255 g",
     "volume": "250 ml",
     "charges": 1,
@@ -84,16 +88,17 @@
     "sealed": false,
     "quench": 50,
     "ammo_data": { "ammo_type": "water" },
-    "flags": [ "EATEN_COLD", "NUTRIENT_OVERRIDE", "NO_AUTO_CONSUME" ],
-    "consumption_effect_on_conditions": [ "EOC_PHOTOKIN_POTION" ]
+    "flags": ["EATEN_COLD", "NUTRIENT_OVERRIDE", "NO_AUTO_CONSUME"],
+    "consumption_effect_on_conditions": ["EOC_PHOTOKIN_POTION"]
   },
   {
     "id": "matrix_crystal_pyrokin_dust_potion",
-    "type": "COMESTIBLE",
+    "type": "ITEM",
+    "subtypes": ["COMESTIBLE"],
     "comestible_type": "DRINK",
     "name": { "str_sp": "red crystalline elixir" },
     "description": "Refined matrix crystal mixed directly into water.  The liquid has a faint red glow.",
-    "material": [ "water" ],
+    "material": ["water"],
     "weight": "255 g",
     "volume": "250 ml",
     "charges": 1,
@@ -106,16 +111,17 @@
     "sealed": false,
     "quench": 50,
     "ammo_data": { "ammo_type": "water" },
-    "flags": [ "EATEN_COLD", "NUTRIENT_OVERRIDE", "NO_AUTO_CONSUME" ],
-    "consumption_effect_on_conditions": [ "EOC_PYROKIN_POTION" ]
+    "flags": ["EATEN_COLD", "NUTRIENT_OVERRIDE", "NO_AUTO_CONSUME"],
+    "consumption_effect_on_conditions": ["EOC_PYROKIN_POTION"]
   },
   {
     "id": "matrix_crystal_telekin_dust_potion",
-    "type": "COMESTIBLE",
+    "type": "ITEM",
+    "subtypes": ["COMESTIBLE"],
     "comestible_type": "DRINK",
     "name": { "str_sp": "yellow crystalline elixir" },
     "description": "Refined matrix crystal mixed directly into water.  The liquid has a faint yellow glow.",
-    "material": [ "water" ],
+    "material": ["water"],
     "weight": "255 g",
     "volume": "250 ml",
     "charges": 1,
@@ -128,16 +134,17 @@
     "sealed": false,
     "quench": 50,
     "ammo_data": { "ammo_type": "water" },
-    "flags": [ "EATEN_COLD", "NUTRIENT_OVERRIDE", "NO_AUTO_CONSUME" ],
-    "consumption_effect_on_conditions": [ "EOC_TELEKIN_POTION" ]
+    "flags": ["EATEN_COLD", "NUTRIENT_OVERRIDE", "NO_AUTO_CONSUME"],
+    "consumption_effect_on_conditions": ["EOC_TELEKIN_POTION"]
   },
   {
     "id": "matrix_crystal_telepath_dust_potion",
-    "type": "COMESTIBLE",
+    "type": "ITEM",
+    "subtypes": ["COMESTIBLE"],
     "comestible_type": "DRINK",
     "name": { "str_sp": "white crystalline elixir" },
     "description": "Refined matrix crystal mixed directly into water.  The liquid has a faint white glow.",
-    "material": [ "water" ],
+    "material": ["water"],
     "weight": "255 g",
     "volume": "250 ml",
     "charges": 1,
@@ -150,16 +157,17 @@
     "sealed": false,
     "quench": 50,
     "ammo_data": { "ammo_type": "water" },
-    "flags": [ "EATEN_COLD", "NUTRIENT_OVERRIDE", "NO_AUTO_CONSUME" ],
-    "consumption_effect_on_conditions": [ "EOC_TELEPATH_POTION" ]
+    "flags": ["EATEN_COLD", "NUTRIENT_OVERRIDE", "NO_AUTO_CONSUME"],
+    "consumption_effect_on_conditions": ["EOC_TELEPATH_POTION"]
   },
   {
     "id": "matrix_crystal_teleport_dust_potion",
-    "type": "COMESTIBLE",
+    "type": "ITEM",
+    "subtypes": ["COMESTIBLE"],
     "comestible_type": "DRINK",
     "name": { "str_sp": "blue crystalline elixir" },
     "description": "Refined matrix crystal mixed directly into water.  The liquid has a faint blue glow.",
-    "material": [ "water" ],
+    "material": ["water"],
     "weight": "255 g",
     "volume": "250 ml",
     "charges": 1,
@@ -172,16 +180,17 @@
     "sealed": false,
     "quench": 50,
     "ammo_data": { "ammo_type": "water" },
-    "flags": [ "EATEN_COLD", "NUTRIENT_OVERRIDE", "NO_AUTO_CONSUME" ],
-    "consumption_effect_on_conditions": [ "EOC_TELEPORT_POTION" ]
+    "flags": ["EATEN_COLD", "NUTRIENT_OVERRIDE", "NO_AUTO_CONSUME"],
+    "consumption_effect_on_conditions": ["EOC_TELEPORT_POTION"]
   },
   {
     "id": "matrix_crystal_vitakin_dust_potion",
-    "type": "COMESTIBLE",
+    "type": "ITEM",
+    "subtypes": ["COMESTIBLE"],
     "comestible_type": "DRINK",
     "name": { "str_sp": "green crystalline elixir" },
     "description": "Refined matrix crystal mixed directly into water.  The liquid has a faint green glow.",
-    "material": [ "water" ],
+    "material": ["water"],
     "weight": "255 g",
     "volume": "250 ml",
     "charges": 1,
@@ -194,11 +203,12 @@
     "sealed": false,
     "quench": 50,
     "ammo_data": { "ammo_type": "water" },
-    "flags": [ "EATEN_COLD", "NUTRIENT_OVERRIDE", "NO_AUTO_CONSUME" ],
-    "consumption_effect_on_conditions": [ "EOC_VITAKIN_POTION" ]
+    "flags": ["EATEN_COLD", "NUTRIENT_OVERRIDE", "NO_AUTO_CONSUME"],
+    "consumption_effect_on_conditions": ["EOC_VITAKIN_POTION"]
   },
   {
-    "type": "COMESTIBLE",
+    "type": "ITEM",
+    "subtypes": ["COMESTIBLE"],
     "id": "alien_tree_1_fruit",
     "name": { "str": "alien fruit" },
     "description": "A bluish-green ovoid globule, firm to the touch but looking more like gelatin than something you plucked from a tree.  It has a strong acrid odor.",
@@ -211,10 +221,11 @@
     "quench": 5,
     "calories": 20,
     "fun": -6,
-    "vitamins": [ [ "mutant_toxin", 800 ] ]
+    "vitamins": [["mutant_toxin", 800]]
   },
   {
-    "type": "COMESTIBLE",
+    "type": "ITEM",
+    "subtypes": ["COMESTIBLE"],
     "id": "egg_cockatrice",
     "name": { "str": "cockatrice egg" },
     "copy-from": "egg_chicken",
@@ -223,12 +234,13 @@
   },
   {
     "id": "black_nether_water",
-    "type": "COMESTIBLE",
+    "type": "ITEM",
+    "subtypes": ["COMESTIBLE"],
     "comestible_type": "DRINK",
     "name": { "str_sp": "black liquid" },
     "description": "You don't know what this is but now that you've gotten a closer look it's definitely not water.  It's completely opaque and freezing cold to the touch, but when you pull your fingertip out of it, your skin is dry as a bone.",
     "category": "food",
-    "material": [ "black_liquid" ],
+    "material": ["black_liquid"],
     "weight": "500 g",
     "volume": "250 ml",
     "charges": 1,
@@ -237,14 +249,20 @@
     "symbol": "~",
     "color": "black",
     "phase": "liquid",
-    "flags": [ "NUTRIENT_OVERRIDE", "TRADER_AVOID" ],
-    "contamination": [ { "disease": "black_nether_water_disease", "probability": 100 } ],
+    "flags": ["NUTRIENT_OVERRIDE", "TRADER_AVOID"],
+    "contamination": [
+      { "disease": "black_nether_water_disease", "probability": 100 }
+    ],
     "fun": -5
   },
   {
-    "type": "COMESTIBLE",
+    "type": "ITEM",
+    "subtypes": ["COMESTIBLE"],
     "id": "alien_meadow_bush_2_fruit",
-    "name": { "str": "handful of alien berries", "str_pl": "handfuls of alien berries" },
+    "name": {
+      "str": "handful of alien berries",
+      "str_pl": "handfuls of alien berries"
+    },
     "description": "A handful of white berries plucked from an otherworldly bush.  You're not sure if eating them is a good idea, but they sure look tasty.",
     "weight": "156 g",
     "color": "white",
@@ -255,14 +273,15 @@
     "calories": 54,
     "price": "2 USD 21 cent",
     "price_postapoc": "1 USD",
-    "material": [ "fruit" ],
+    "material": ["fruit"],
     "volume": "250 ml",
     "fun": 1,
-    "flags": [ "EDIBLE_FROZEN" ],
-    "consumption_effect_on_conditions": [ "EOC_ALIEN_MEADOW_BUSH_2_BERRIES" ]
+    "flags": ["EDIBLE_FROZEN"],
+    "consumption_effect_on_conditions": ["EOC_ALIEN_MEADOW_BUSH_2_BERRIES"]
   },
   {
-    "type": "COMESTIBLE",
+    "type": "ITEM",
+    "subtypes": ["COMESTIBLE"],
     "id": "alien_meadow_tree_3_fruit",
     "name": { "str": "alien fruit" },
     "description": "A large fruit pulled from an alien tree.  The rind is extremely hard and you'll need to cut into it to eat it.",
@@ -275,14 +294,19 @@
     "calories": 1355,
     "price": "7 USD 58 cent",
     "price_postapoc": "2 USD",
-    "material": [ "fruit" ],
+    "material": ["fruit"],
     "volume": "7150 ml",
-    "flags": [ "FREEZERBURN", "INEDIBLE" ],
-    "vitamins": [ [ "vitC", "366 mg" ], [ "iron", "35800 μg" ], [ "calcium", "32300 μg" ] ],
+    "flags": ["FREEZERBURN", "INEDIBLE"],
+    "vitamins": [
+      ["vitC", "366 mg"],
+      ["iron", "35800 μg"],
+      ["calcium", "32300 μg"]
+    ],
     "melee_damage": { "bash": 2 }
   },
   {
-    "type": "COMESTIBLE",
+    "type": "ITEM",
+    "subtypes": ["COMESTIBLE"],
     "id": "egg_pigeon_passenger",
     "name": { "str": "feral pigeon egg" },
     "copy-from": "egg_pigeon"

--- a/items/files_and_post_it.json
+++ b/items/files_and_post_it.json
@@ -1,6 +1,6 @@
 [
   {
-    "type": "GENERIC",
+    "type": "ITEM",
     "id": "lab_postit_psi",
     "category": "books",
     "symbol": ",",
@@ -10,14 +10,14 @@
     "description": "A bright yellow post-it note.",
     "price": "0 cent",
     "price_postapoc": "0 cent",
-    "material": [ "paper" ],
-    "flags": [ "TRADER_AVOID" ],
+    "material": ["paper"],
+    "flags": ["TRADER_AVOID"],
     "weight": "12 mg",
     "volume": "1 ml",
     "copy-from": "lab_postit_bio"
   },
   {
-    "type": "GENERIC",
+    "type": "ITEM",
     "id": "lab_file_private_correspondence",
     "name": { "str": "private note" },
     "category": "books",
@@ -27,15 +27,18 @@
     "to_hit": -3,
     "color": "white",
     "symbol": ",",
-    "material": [ "paper" ],
+    "material": ["paper"],
     "volume": "6 ml",
-    "flags": [ "TRADER_AVOID" ],
+    "flags": ["TRADER_AVOID"],
     "copy-from": "file"
   },
   {
-    "type": "GENERIC",
+    "type": "ITEM",
     "id": "lab_file_biokinesis_item",
-    "name": { "str": "report (BURNT NOVEMBER)", "str_pl": "copies of report (BURNT NOVEMBER)" },
+    "name": {
+      "str": "report (BURNT NOVEMBER)",
+      "str_pl": "copies of report (BURNT NOVEMBER)"
+    },
     "category": "books",
     "description": "A folder full of what appear to be transcripts of experimental results or reports, with the heading \"BURNT NOVEMBER\".  Most of it is rather trivial, but certain passages catch your eye…",
     "snippet_category": "lab_file_biokinesis",
@@ -43,15 +46,18 @@
     "to_hit": -3,
     "color": "white",
     "symbol": ",",
-    "material": [ "paper" ],
+    "material": ["paper"],
     "volume": "50 ml",
-    "flags": [ "TRADER_AVOID" ],
+    "flags": ["TRADER_AVOID"],
     "copy-from": "file"
   },
   {
-    "type": "GENERIC",
+    "type": "ITEM",
     "id": "lab_file_clairsentience_item",
-    "name": { "str": "report (NOBLE HORIZON)", "str_pl": "copies of report (NOBLE HORIZON)" },
+    "name": {
+      "str": "report (NOBLE HORIZON)",
+      "str_pl": "copies of report (NOBLE HORIZON)"
+    },
     "category": "books",
     "description": "A folder full of what appear to be transcripts of experimental results or reports, with the heading \"NOBLE HORIZON\".  Most of it is rather trivial, but certain passages catch your eye…",
     "snippet_category": "lab_file_clairsentience",
@@ -59,15 +65,18 @@
     "to_hit": -3,
     "color": "white",
     "symbol": ",",
-    "material": [ "paper" ],
+    "material": ["paper"],
     "volume": "50 ml",
-    "flags": [ "TRADER_AVOID" ],
+    "flags": ["TRADER_AVOID"],
     "copy-from": "file"
   },
   {
-    "type": "GENERIC",
+    "type": "ITEM",
     "id": "lab_file_electrokinesis_item",
-    "name": { "str": "report (RUBY LOOP)", "str_pl": "copies of report (RUBY LOOP)" },
+    "name": {
+      "str": "report (RUBY LOOP)",
+      "str_pl": "copies of report (RUBY LOOP)"
+    },
     "category": "books",
     "description": "A folder full of what appear to be transcripts of experimental results or reports, with the heading \"RUBY LOOP\".  Most of it is rather trivial, but certain passages catch your eye…",
     "snippet_category": "lab_file_electrokinesis",
@@ -75,15 +84,18 @@
     "to_hit": -3,
     "color": "white",
     "symbol": ",",
-    "material": [ "paper" ],
+    "material": ["paper"],
     "volume": "50 ml",
-    "flags": [ "TRADER_AVOID" ],
+    "flags": ["TRADER_AVOID"],
     "copy-from": "file"
   },
   {
-    "type": "GENERIC",
+    "type": "ITEM",
     "id": "lab_file_photokinesis_item",
-    "name": { "str": "report (CRYPTIC FORGE)", "str_pl": "copies of report (CRYPTIC FORGE)" },
+    "name": {
+      "str": "report (CRYPTIC FORGE)",
+      "str_pl": "copies of report (CRYPTIC FORGE)"
+    },
     "category": "books",
     "description": "A folder full of what appear to be transcripts of experimental results or reports, with the heading \"CRYPTIC FORGE\".  Most of it is rather trivial, but certain passages catch your eye…",
     "snippet_category": "lab_file_photokinesis",
@@ -91,15 +103,18 @@
     "to_hit": -3,
     "color": "white",
     "symbol": ",",
-    "material": [ "paper" ],
+    "material": ["paper"],
     "volume": "50 ml",
-    "flags": [ "TRADER_AVOID" ],
+    "flags": ["TRADER_AVOID"],
     "copy-from": "file"
   },
   {
-    "type": "GENERIC",
+    "type": "ITEM",
     "id": "lab_file_pyrokinesis_item",
-    "name": { "str": "report (COPPER PRIME)", "str_pl": "copies of report (COPPER PRIME)" },
+    "name": {
+      "str": "report (COPPER PRIME)",
+      "str_pl": "copies of report (COPPER PRIME)"
+    },
     "category": "books",
     "description": "A folder full of what appear to be transcripts of experimental results or reports, with the heading \"COPPER PRIME\".  Most of it is rather trivial, but certain passages catch your eye…",
     "snippet_category": "lab_file_pyrokinesis",
@@ -107,15 +122,18 @@
     "to_hit": -3,
     "color": "white",
     "symbol": ",",
-    "material": [ "paper" ],
+    "material": ["paper"],
     "volume": "50 ml",
-    "flags": [ "TRADER_AVOID" ],
+    "flags": ["TRADER_AVOID"],
     "copy-from": "file"
   },
   {
-    "type": "GENERIC",
+    "type": "ITEM",
     "id": "lab_file_telekinesis_item",
-    "name": { "str": "report (JUNIPER GOLD)", "str_pl": "copies of report (JUNIPER GOLD)" },
+    "name": {
+      "str": "report (JUNIPER GOLD)",
+      "str_pl": "copies of report (JUNIPER GOLD)"
+    },
     "category": "books",
     "description": "A folder full of what appear to be transcripts of experimental results or reports, with the heading \"JUNIPER GOLD\".  Most of it is rather trivial, but certain passages catch your eye…",
     "snippet_category": "lab_file_telekinesis",
@@ -123,15 +141,18 @@
     "to_hit": -3,
     "color": "white",
     "symbol": ",",
-    "material": [ "paper" ],
+    "material": ["paper"],
     "volume": "50 ml",
-    "flags": [ "TRADER_AVOID" ],
+    "flags": ["TRADER_AVOID"],
     "copy-from": "file"
   },
   {
-    "type": "GENERIC",
+    "type": "ITEM",
     "id": "lab_file_telepathy_item",
-    "name": { "str": "report (GRAY DAWN)", "str_pl": "copies of report (GRAY DAWN)" },
+    "name": {
+      "str": "report (GRAY DAWN)",
+      "str_pl": "copies of report (GRAY DAWN)"
+    },
     "category": "books",
     "description": "A folder full of what appear to be transcripts of experimental results or reports, with the heading \"GRAY DAWN\".  Most of it is rather trivial, but certain passages catch your eye…",
     "snippet_category": "lab_file_telepathy",
@@ -139,15 +160,18 @@
     "to_hit": -3,
     "color": "white",
     "symbol": ",",
-    "material": [ "paper" ],
+    "material": ["paper"],
     "volume": "50 ml",
-    "flags": [ "TRADER_AVOID" ],
+    "flags": ["TRADER_AVOID"],
     "copy-from": "file"
   },
   {
-    "type": "GENERIC",
+    "type": "ITEM",
     "id": "lab_file_teleportation_item",
-    "name": { "str": "report (LOST RAIN)", "str_pl": "copies of report (LOST RAIN)" },
+    "name": {
+      "str": "report (LOST RAIN)",
+      "str_pl": "copies of report (LOST RAIN)"
+    },
     "category": "books",
     "description": "A folder full of what appear to be transcripts of experimental results or reports, with the heading \"LOST RAIN\".  Most of it is rather trivial, but certain passages catch your eye…",
     "snippet_category": "lab_file_teleportation",
@@ -155,15 +179,18 @@
     "to_hit": -3,
     "color": "white",
     "symbol": ",",
-    "material": [ "paper" ],
+    "material": ["paper"],
     "volume": "50 ml",
-    "flags": [ "TRADER_AVOID" ],
+    "flags": ["TRADER_AVOID"],
     "copy-from": "file"
   },
   {
-    "type": "GENERIC",
+    "type": "ITEM",
     "id": "lab_file_vitakinesis_item",
-    "name": { "str": "report (SMOKE USHER)", "str_pl": "copies of report (SMOKE USHER)" },
+    "name": {
+      "str": "report (SMOKE USHER)",
+      "str_pl": "copies of report (SMOKE USHER)"
+    },
     "category": "books",
     "description": "A folder full of what appear to be transcripts of experimental results or reports, with the heading \"SMOKE USHER\".  Most of it is rather trivial, but certain passages catch your eye…",
     "snippet_category": "lab_file_vitakinesis",
@@ -171,15 +198,18 @@
     "to_hit": -3,
     "color": "white",
     "symbol": ",",
-    "material": [ "paper" ],
+    "material": ["paper"],
     "volume": "50 ml",
-    "flags": [ "TRADER_AVOID" ],
+    "flags": ["TRADER_AVOID"],
     "copy-from": "file"
   },
   {
-    "type": "GENERIC",
+    "type": "ITEM",
     "id": "lab_file_matrix_research_item",
-    "name": { "str": "report (matrix technology)", "str_pl": "copies of report (matrix technology)" },
+    "name": {
+      "str": "report (matrix technology)",
+      "str_pl": "copies of report (matrix technology)"
+    },
     "category": "books",
     "description": "A folder full of what appear to be transcripts of experimental results or reports.  Most of it is rather trivial, but certain passages catch your eye…",
     "snippet_category": "lab_file_matrix_research",
@@ -187,15 +217,18 @@
     "to_hit": -3,
     "color": "white",
     "symbol": ",",
-    "material": [ "paper" ],
+    "material": ["paper"],
     "volume": "50 ml",
-    "flags": [ "TRADER_AVOID" ],
+    "flags": ["TRADER_AVOID"],
     "copy-from": "file"
   },
   {
-    "type": "GENERIC",
+    "type": "ITEM",
     "id": "lab_file_OS647_P_item",
-    "name": { "str": "OS647-P Proposal Response", "str_pl": "copies of OS647-P Proposal Response" },
+    "name": {
+      "str": "OS647-P Proposal Response",
+      "str_pl": "copies of OS647-P Proposal Response"
+    },
     "category": "books",
     "description": "A note written on official XEDRA letterhead.",
     "snippet_category": "lab_file_OS647_P",
@@ -203,15 +236,18 @@
     "to_hit": -3,
     "color": "white",
     "symbol": ",",
-    "material": [ "paper" ],
+    "material": ["paper"],
     "volume": "50 ml",
-    "flags": [ "TRADER_AVOID" ],
+    "flags": ["TRADER_AVOID"],
     "copy-from": "file"
   },
   {
-    "type": "GENERIC",
+    "type": "ITEM",
     "id": "lab_file_QD944_P_item",
-    "name": { "str": "QD944-P Progress Update", "str_pl": "copies of QD944-P Progress Update" },
+    "name": {
+      "str": "QD944-P Progress Update",
+      "str_pl": "copies of QD944-P Progress Update"
+    },
     "category": "books",
     "description": "A note written on official XEDRA letterhead.",
     "snippet_category": "lab_file_QD944_P",
@@ -219,13 +255,13 @@
     "to_hit": -3,
     "color": "white",
     "symbol": ",",
-    "material": [ "paper" ],
+    "material": ["paper"],
     "volume": "50 ml",
-    "flags": [ "TRADER_AVOID" ],
+    "flags": ["TRADER_AVOID"],
     "copy-from": "file"
   },
   {
-    "type": "GENERIC",
+    "type": "ITEM",
     "id": "lab_file_IG882_P_item",
     "name": { "str": "IG882-P Report", "str_pl": "copies of IG882-P Report" },
     "category": "books",
@@ -235,15 +271,18 @@
     "to_hit": -3,
     "color": "white",
     "symbol": ",",
-    "material": [ "paper" ],
+    "material": ["paper"],
     "volume": "50 ml",
-    "flags": [ "TRADER_AVOID" ],
+    "flags": ["TRADER_AVOID"],
     "copy-from": "file"
   },
   {
-    "type": "GENERIC",
+    "type": "ITEM",
     "id": "lab_file_phavian_memo_item",
-    "name": { "str": "Project PHAVIAN memo", "str_pl": "copies of Project PHAVIAN memo" },
+    "name": {
+      "str": "Project PHAVIAN memo",
+      "str_pl": "copies of Project PHAVIAN memo"
+    },
     "category": "books",
     "description": "A note written on official XEDRA letterhead.",
     "snippet_category": "lab_file_phavian_memo",
@@ -251,15 +290,18 @@
     "to_hit": -3,
     "color": "white",
     "symbol": ",",
-    "material": [ "paper" ],
+    "material": ["paper"],
     "volume": "50 ml",
-    "flags": [ "TRADER_AVOID" ],
+    "flags": ["TRADER_AVOID"],
     "copy-from": "file"
   },
   {
-    "type": "GENERIC",
+    "type": "ITEM",
     "id": "lab_file_obsidian_ring_item",
-    "name": { "str": "report (OBSIDIAN RING)", "str_pl": "copies of report (OBSIDIAN RING)" },
+    "name": {
+      "str": "report (OBSIDIAN RING)",
+      "str_pl": "copies of report (OBSIDIAN RING)"
+    },
     "category": "books",
     "description": "A folder full of what appear to be transcripts of experimental results or reports, with a large \"Project OBSIDIAN RING\" on the front.  Most of it is rather trivial, but certain passages catch your eye…",
     "snippet_category": "lab_file_obsidian_ring",
@@ -267,13 +309,13 @@
     "to_hit": -3,
     "color": "white",
     "symbol": ",",
-    "material": [ "paper" ],
+    "material": ["paper"],
     "volume": "50 ml",
-    "flags": [ "TRADER_AVOID" ],
+    "flags": ["TRADER_AVOID"],
     "copy-from": "file"
   },
   {
-    "type": "GENERIC",
+    "type": "ITEM",
     "id": "id_science_visitor_phavian",
     "symbol": ",",
     "color": "red",
@@ -281,9 +323,9 @@
     "copy-from": "card_plastic_abstract",
     "description": "A visitor's pass to some sort of facility.  The reverse side describes the protocol for using it; this could grant one-time access at a card reader, if you can find one.  It also lists the addresses of nearby facilities; activate it to add their locations to your map.  There is a prominent symbol stamped on it with the word \"PHAVIAN\" underneath.",
     "price": "600 USD",
-    "flags": [ "CREDIT_CARD_SHAPED", "SCIENCE_CARD_VISITOR" ],
+    "flags": ["CREDIT_CARD_SHAPED", "SCIENCE_CARD_VISITOR"],
     "price_postapoc": "2 USD 50 cent",
-    "material": [ "plastic" ],
+    "material": ["plastic"],
     "weight": "5 g",
     "volume": "5 ml",
     "longest_side": "84 mm",

--- a/items/laser_overrides.json
+++ b/items/laser_overrides.json
@@ -1,58 +1,98 @@
 [
   {
-    "type": "GUN",
+    "type": "ITEM",
+    "subtypes": ["GUN"],
     "id": "laser_rifle",
     "copy-from": "laser_rifle",
     "name": { "str": "A7 laser rifle" },
-    "ranged_damage": { "damage_type": "psi_photokinetic_damage", "amount": 25, "armor_penetration": 4 }
+    "ranged_damage": {
+      "damage_type": "psi_photokinetic_damage",
+      "amount": 25,
+      "armor_penetration": 4
+    }
   },
   {
-    "type": "GUN",
+    "type": "ITEM",
+    "subtypes": ["GUN"],
     "id": "bio_laser_gun",
     "copy-from": "bio_laser_gun",
     "name": { "str": "laser finger" },
-    "ranged_damage": { "damage_type": "psi_photokinetic_damage", "amount": 10, "armor_penetration": 4 }
+    "ranged_damage": {
+      "damage_type": "psi_photokinetic_damage",
+      "amount": 10,
+      "armor_penetration": 4
+    }
   },
   {
-    "type": "GUN",
+    "type": "ITEM",
+    "subtypes": ["GUN"],
     "id": "v29",
     "copy-from": "v29",
     "name": { "str": "V29 laser pistol" },
-    "ranged_damage": { "damage_type": "psi_photokinetic_damage", "amount": 10, "armor_penetration": 4 }
+    "ranged_damage": {
+      "damage_type": "psi_photokinetic_damage",
+      "amount": 10,
+      "armor_penetration": 4
+    }
   },
   {
-    "type": "GUN",
+    "type": "ITEM",
+    "subtypes": ["GUN"],
     "id": "v29_turret",
     "copy-from": "v29_turret",
     "name": { "str": "mounted laser" },
-    "ranged_damage": { "damage_type": "psi_photokinetic_damage", "amount": 10, "armor_penetration": 4 }
+    "ranged_damage": {
+      "damage_type": "psi_photokinetic_damage",
+      "amount": 10,
+      "armor_penetration": 4
+    }
   },
   {
-    "type": "GUN",
+    "type": "ITEM",
+    "subtypes": ["GUN"],
     "id": "recon_mech_laser_single",
     "copy-from": "recon_mech_laser_single",
     "name": { "str": "salvaged RMES marksman laser" },
-    "ranged_damage": { "damage_type": "psi_photokinetic_damage", "amount": 30, "armor_penetration": 4 }
+    "ranged_damage": {
+      "damage_type": "psi_photokinetic_damage",
+      "amount": 30,
+      "armor_penetration": 4
+    }
   },
   {
-    "type": "GUN",
+    "type": "ITEM",
+    "subtypes": ["GUN"],
     "id": "recon_mech_laser",
     "copy-from": "recon_mech_laser",
     "name": { "str": "RMES marksman system" },
-    "ranged_damage": { "damage_type": "psi_photokinetic_damage", "amount": 30, "armor_penetration": 4 }
+    "ranged_damage": {
+      "damage_type": "psi_photokinetic_damage",
+      "amount": 30,
+      "armor_penetration": 4
+    }
   },
   {
-    "type": "GUN",
+    "type": "ITEM",
+    "subtypes": ["GUN"],
     "id": "gatling_mech_laser_single",
     "copy-from": "gatling_mech_laser_single",
     "name": { "str": "salvaged CMES laser cannon" },
-    "ranged_damage": { "damage_type": "psi_photokinetic_damage", "amount": 20, "armor_penetration": 4 }
+    "ranged_damage": {
+      "damage_type": "psi_photokinetic_damage",
+      "amount": 20,
+      "armor_penetration": 4
+    }
   },
   {
-    "type": "GUN",
+    "type": "ITEM",
+    "subtypes": ["GUN"],
     "id": "gatling_mech_laser",
     "copy-from": "gatling_mech_laser",
     "name": { "str": "CMES laser cannon" },
-    "ranged_damage": { "damage_type": "psi_photokinetic_damage", "amount": 20, "armor_penetration": 4 }
+    "ranged_damage": {
+      "damage_type": "psi_photokinetic_damage",
+      "amount": 20,
+      "armor_penetration": 4
+    }
   }
 ]

--- a/items/matrix_crystals.json
+++ b/items/matrix_crystals.json
@@ -1,6 +1,7 @@
 [
   {
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "id": "matrix_crystal_biokinesis",
     "name": { "str_sp": "strange crystal, pink" },
     "description": "A strange-looking, surprisingly-heavy crystal with a faintly-glowing pink light in its depths.  Holding it, you feel more capable.",
@@ -9,17 +10,17 @@
     "volume": "10 ml",
     "weight": "150 g",
     "longest_side": "21 mm",
-    "material": [ "nether_crystal" ],
+    "material": ["nether_crystal"],
     "looks_like": "art_crystal",
-    "flags": [ "MATRIX_CRYSTAL_BIOKINESIS" ],
+    "flags": ["MATRIX_CRYSTAL_BIOKINESIS"],
     "use_action": {
       "type": "effect_on_conditions",
       "description": "The pink glow calls to you.",
-      "effect_on_conditions": [ "EOC_BIOKIN_MATRIX_AWAKENING" ]
+      "effect_on_conditions": ["EOC_BIOKIN_MATRIX_AWAKENING"]
     }
   },
   {
-    "type": "GENERIC",
+    "type": "ITEM",
     "id": "matrix_crystal_biokin_dust",
     "name": { "str_sp": "crystalline dust, pink" },
     "description": "A bit of crystalline dust with a faint pink shimmer.",
@@ -27,11 +28,11 @@
     "symbol": "=",
     "volume": "1 ml",
     "weight": "15 g",
-    "material": [ "powder_nonflam" ],
+    "material": ["powder_nonflam"],
     "looks_like": "material_quicklime"
   },
   {
-    "type": "GENERIC",
+    "type": "ITEM",
     "id": "matrix_crystal_biokin_dust_refined",
     "name": { "str_sp": "refined matrix crystal powder, pink" },
     "description": "Concentrated matrix crystal dust.  It glitters pink even in complete darkness.",
@@ -39,25 +40,26 @@
     "symbol": "=",
     "volume": "1 ml",
     "weight": "5 g",
-    "material": [ "powder_nonflam" ],
+    "material": ["powder_nonflam"],
     "looks_like": "material_quicklime"
   },
   {
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "id": "matrix_crystal_clairsentience",
     "name": { "str_sp": "strange crystal, gray" },
     "copy-from": "matrix_crystal_biokinesis",
     "description": "A strange-looking, surprisingly-heavy crystal with a faintly-glowing gray light in its depths.  Holding it, you feel more perceptive.",
     "color": "dark_gray",
-    "flags": [ "MATRIX_CRYSTAL_CLAIRSENTIENCE" ],
+    "flags": ["MATRIX_CRYSTAL_CLAIRSENTIENCE"],
     "use_action": {
       "type": "effect_on_conditions",
       "description": "The gray glow calls to you.",
-      "effect_on_conditions": [ "EOC_CLAIR_MATRIX_AWAKENING" ]
+      "effect_on_conditions": ["EOC_CLAIR_MATRIX_AWAKENING"]
     }
   },
   {
-    "type": "GENERIC",
+    "type": "ITEM",
     "id": "matrix_crystal_clair_dust",
     "name": { "str_sp": "crystalline dust, gray" },
     "copy-from": "matrix_crystal_biokin_dust",
@@ -65,7 +67,7 @@
     "color": "dark_gray"
   },
   {
-    "type": "GENERIC",
+    "type": "ITEM",
     "id": "matrix_crystal_clair_dust_refined",
     "name": { "str_sp": "refined matrix crystal powder, gray" },
     "description": "Concentrated matrix crystal dust.  It glitters gray even in complete darkness.",
@@ -73,21 +75,22 @@
     "color": "dark_gray"
   },
   {
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "id": "matrix_crystal_electrokinesis",
     "name": { "str_sp": "strange crystal, cyan" },
     "copy-from": "matrix_crystal_biokinesis",
     "description": "A strange-looking, surprisingly-heavy crystal with a faintly-glowing cyan light in its depths.  Holding it, you feel more energetic.",
     "color": "cyan",
-    "flags": [ "MATRIX_CRYSTAL_ELECTROKINESIS" ],
+    "flags": ["MATRIX_CRYSTAL_ELECTROKINESIS"],
     "use_action": {
       "type": "effect_on_conditions",
       "description": "The cyan glow calls to you.",
-      "effect_on_conditions": [ "EOC_ELECTRO_MATRIX_AWAKENING" ]
+      "effect_on_conditions": ["EOC_ELECTRO_MATRIX_AWAKENING"]
     }
   },
   {
-    "type": "GENERIC",
+    "type": "ITEM",
     "id": "matrix_crystal_electrokin_dust",
     "name": { "str_sp": "crystalline dust, cyan" },
     "copy-from": "matrix_crystal_biokin_dust",
@@ -95,7 +98,7 @@
     "color": "cyan"
   },
   {
-    "type": "GENERIC",
+    "type": "ITEM",
     "id": "matrix_crystal_electrokin_dust_refined",
     "name": { "str_sp": "refined matrix crystal powder, cyan" },
     "description": "Concentrated matrix crystal dust.  It glitters cyan even in complete darkness.",
@@ -103,21 +106,22 @@
     "color": "cyan"
   },
   {
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "id": "matrix_crystal_photokinesis",
     "name": { "str_sp": "strange crystal, golden" },
     "copy-from": "matrix_crystal_biokinesis",
     "description": "A strange-looking, surprisingly-heavy crystal with a faintly-glowing golden light in its depths.  Holding it, you feel radiant.",
     "color": "yellow",
-    "flags": [ "MATRIX_CRYSTAL_PHOTOKINESIS" ],
+    "flags": ["MATRIX_CRYSTAL_PHOTOKINESIS"],
     "use_action": {
       "type": "effect_on_conditions",
       "description": "The golden glow calls to you.",
-      "effect_on_conditions": [ "EOC_PHOTOKIN_MATRIX_AWAKENING" ]
+      "effect_on_conditions": ["EOC_PHOTOKIN_MATRIX_AWAKENING"]
     }
   },
   {
-    "type": "GENERIC",
+    "type": "ITEM",
     "id": "matrix_crystal_photokin_dust",
     "name": { "str_sp": "crystalline dust, golden" },
     "copy-from": "matrix_crystal_biokin_dust",
@@ -125,7 +129,7 @@
     "color": "yellow"
   },
   {
-    "type": "GENERIC",
+    "type": "ITEM",
     "id": "matrix_crystal_photokin_dust_refined",
     "name": { "str_sp": "refined matrix crystal powder, golden" },
     "description": "Concentrated matrix crystal dust.  It glitters gold even in complete darkness.",
@@ -133,21 +137,22 @@
     "color": "yellow"
   },
   {
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "id": "matrix_crystal_pyrokinesis",
     "name": { "str_sp": "strange crystal, red" },
     "copy-from": "matrix_crystal_biokinesis",
     "description": "A strange-looking, surprisingly-heavy crystal with a faintly-glowing red light in its depths.  Holding it, you feel hot.",
     "color": "red",
-    "flags": [ "MATRIX_CRYSTAL_PYROKINESIS" ],
+    "flags": ["MATRIX_CRYSTAL_PYROKINESIS"],
     "use_action": {
       "type": "effect_on_conditions",
       "description": "The red glow calls to you.",
-      "effect_on_conditions": [ "EOC_PYROKIN_MATRIX_AWAKENING" ]
+      "effect_on_conditions": ["EOC_PYROKIN_MATRIX_AWAKENING"]
     }
   },
   {
-    "type": "GENERIC",
+    "type": "ITEM",
     "id": "matrix_crystal_pyrokin_dust",
     "name": { "str_sp": "crystalline dust, red" },
     "copy-from": "matrix_crystal_biokin_dust",
@@ -155,7 +160,7 @@
     "color": "red"
   },
   {
-    "type": "GENERIC",
+    "type": "ITEM",
     "id": "matrix_crystal_pyrokin_dust_refined",
     "name": { "str_sp": "refined matrix crystal powder, red" },
     "description": "Concentrated matrix crystal dust.  It glitters red even in complete darkness.",
@@ -163,21 +168,22 @@
     "color": "red"
   },
   {
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "id": "matrix_crystal_telekinesis",
     "name": { "str_sp": "strange crystal, yellow" },
     "copy-from": "matrix_crystal_biokinesis",
     "description": "A strange-looking, surprisingly-heavy crystal with a faintly-glowing yellow light in its depths.  Holding it, you feel lighter.",
     "color": "yellow",
-    "flags": [ "MATRIX_CRYSTAL_TELEKINESIS" ],
+    "flags": ["MATRIX_CRYSTAL_TELEKINESIS"],
     "use_action": {
       "type": "effect_on_conditions",
       "description": "The yellow glow calls to you.",
-      "effect_on_conditions": [ "EOC_TELEKIN_MATRIX_AWAKENING" ]
+      "effect_on_conditions": ["EOC_TELEKIN_MATRIX_AWAKENING"]
     }
   },
   {
-    "type": "GENERIC",
+    "type": "ITEM",
     "id": "matrix_crystal_telekin_dust",
     "name": { "str_sp": "crystalline dust, yellow" },
     "copy-from": "matrix_crystal_biokin_dust",
@@ -185,7 +191,7 @@
     "color": "yellow"
   },
   {
-    "type": "GENERIC",
+    "type": "ITEM",
     "id": "matrix_crystal_telekin_dust_refined",
     "name": { "str_sp": "refined matrix crystal powder, yellow" },
     "description": "Concentrated matrix crystal dust.  It glitters yellow even in complete darkness.",
@@ -193,21 +199,22 @@
     "color": "yellow"
   },
   {
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "id": "matrix_crystal_telepathy",
     "name": { "str_sp": "strange crystal, white" },
     "copy-from": "matrix_crystal_biokinesis",
     "description": "A strange-looking, surprisingly-heavy crystal with a faintly-glowing white light in its depths.  Holding it, you feel pensive.",
     "color": "white",
-    "flags": [ "MATRIX_CRYSTAL_TELEPATHY" ],
+    "flags": ["MATRIX_CRYSTAL_TELEPATHY"],
     "use_action": {
       "type": "effect_on_conditions",
       "description": "The white glow calls to you.",
-      "effect_on_conditions": [ "EOC_TEEP_MATRIX_AWAKENING" ]
+      "effect_on_conditions": ["EOC_TEEP_MATRIX_AWAKENING"]
     }
   },
   {
-    "type": "GENERIC",
+    "type": "ITEM",
     "id": "matrix_crystal_telepath_dust",
     "name": { "str_sp": "crystalline dust, white" },
     "copy-from": "matrix_crystal_biokin_dust",
@@ -215,7 +222,7 @@
     "color": "white"
   },
   {
-    "type": "GENERIC",
+    "type": "ITEM",
     "id": "matrix_crystal_telepath_dust_refined",
     "name": { "str_sp": "refined matrix crystal powder, white" },
     "description": "Concentrated matrix crystal dust.  It glitters white even in complete darkness.",
@@ -223,21 +230,22 @@
     "color": "white"
   },
   {
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "id": "matrix_crystal_teleportation",
     "name": { "str_sp": "strange crystal, blue" },
     "copy-from": "matrix_crystal_biokinesis",
     "description": "A strange-looking, surprisingly-heavy crystal with a faintly-glowing blue light in its depths.  Holding it, you feel more mobile.",
     "color": "blue",
-    "flags": [ "MATRIX_CRYSTAL_TELEPORTATION" ],
+    "flags": ["MATRIX_CRYSTAL_TELEPORTATION"],
     "use_action": {
       "type": "effect_on_conditions",
       "description": "The blue glow calls to you.",
-      "effect_on_conditions": [ "EOC_TELEPORT_MATRIX_AWAKENING" ]
+      "effect_on_conditions": ["EOC_TELEPORT_MATRIX_AWAKENING"]
     }
   },
   {
-    "type": "GENERIC",
+    "type": "ITEM",
     "id": "matrix_crystal_teleport_dust",
     "name": { "str_sp": "crystalline dust, blue" },
     "copy-from": "matrix_crystal_biokin_dust",
@@ -245,7 +253,7 @@
     "color": "blue"
   },
   {
-    "type": "GENERIC",
+    "type": "ITEM",
     "id": "matrix_crystal_teleport_dust_refined",
     "name": { "str_sp": "refined matrix crystal powder, blue" },
     "description": "Concentrated matrix crystal dust.  It glitters blue even in complete darkness.",
@@ -253,21 +261,22 @@
     "color": "blue"
   },
   {
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "id": "matrix_crystal_vitakinesis",
     "name": { "str_sp": "strange crystal, green" },
     "copy-from": "matrix_crystal_biokinesis",
     "description": "A strange-looking, surprisingly-heavy crystal with a faintly-glowing green light in its depths.  Holding it, you feel healthier.",
     "color": "green",
-    "flags": [ "MATRIX_CRYSTAL_VITAKINESIS" ],
+    "flags": ["MATRIX_CRYSTAL_VITAKINESIS"],
     "use_action": {
       "type": "effect_on_conditions",
       "description": "The green glow calls to you.",
-      "effect_on_conditions": [ "EOC_VITAKIN_MATRIX_AWAKENING" ]
+      "effect_on_conditions": ["EOC_VITAKIN_MATRIX_AWAKENING"]
     }
   },
   {
-    "type": "GENERIC",
+    "type": "ITEM",
     "id": "matrix_crystal_vitakin_dust",
     "name": { "str_sp": "crystalline dust, green" },
     "copy-from": "matrix_crystal_biokin_dust",
@@ -275,7 +284,7 @@
     "color": "green"
   },
   {
-    "type": "GENERIC",
+    "type": "ITEM",
     "id": "matrix_crystal_vitakin_dust_refined",
     "name": { "str_sp": "refined matrix crystal powder, green" },
     "description": "Concentrated matrix crystal dust.  It glitters green even in complete darkness.",
@@ -283,7 +292,8 @@
     "color": "green"
   },
   {
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "id": "matrix_crystal_drained",
     "name": { "str_sp": "strange crystal, black" },
     "description": "A strange-looking, surprisingly-heavy crystal.  In total darkness, there is a faint light visible in its depths.",
@@ -292,16 +302,16 @@
     "volume": "10 ml",
     "weight": "150 g",
     "longest_side": "21 mm",
-    "material": [ "nether_crystal" ],
+    "material": ["nether_crystal"],
     "looks_like": "art_crystal",
     "use_action": {
       "type": "effect_on_conditions",
       "description": "The faint light calls to you.",
-      "effect_on_conditions": [ "EOC_DRAINED_MATRIX" ]
+      "effect_on_conditions": ["EOC_DRAINED_MATRIX"]
     }
   },
   {
-    "type": "GENERIC",
+    "type": "ITEM",
     "id": "matrix_crystal_drained_dust",
     "name": { "str_sp": "crystalline dust, black" },
     "copy-from": "matrix_crystal_biokin_dust",
@@ -309,7 +319,7 @@
     "color": "black"
   },
   {
-    "type": "GENERIC",
+    "type": "ITEM",
     "id": "matrix_crystal_drained_dust_refined",
     "name": { "str_sp": "refined matrix crystal powder, black" },
     "description": "Concentrated matrix crystal dust.  It seems to completely absorb any light that falls on it.",
@@ -317,28 +327,30 @@
     "color": "black"
   },
   {
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "id": "matrix_crystal_coruscating",
     "name": { "str_sp": "strange crystal, coruscating" },
     "description": "A strange-looking, surprisingly-heavy crystal.  In total darkness, multicolored lights churn and swirl within its depths.",
     "copy-from": "matrix_crystal_biokinesis",
     "color": "brown",
-    "flags": [ "MATRIX_CRYSTAL_CORUSCATING" ],
+    "flags": ["MATRIX_CRYSTAL_CORUSCATING"],
     "use_action": {
       "type": "effect_on_conditions",
       "description": "The coruscating light calls to you.",
-      "effect_on_conditions": [ "EOC_CORUSCATING_MATRIX" ]
+      "effect_on_conditions": ["EOC_CORUSCATING_MATRIX"]
     }
   },
   {
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "id": "matrix_shard",
     "symbol": ",",
     "color": "white",
     "name": { "str": "strange crystal shard" },
     "category": "other",
     "description": "A very heavy chunk of a strange crystalline outcropping.  You could use it as a weapon, but you might want to wear gloves.",
-    "material": [ "nether_crystal" ],
+    "material": ["nether_crystal"],
     "weight": "450 g",
     "volume": "30 ml",
     "melee_damage": { "cut": 6 },
@@ -349,7 +361,7 @@
       "practice": 2,
       "done_message": "You carefully place the shards on the ground, ready to be cracked by something passing by."
     },
-    "flags": [ "HURT_WHEN_WIELDED", "TRADER_AVOID" ],
+    "flags": ["HURT_WHEN_WIELDED", "TRADER_AVOID"],
     "to_hit": -1
   }
 ]

--- a/items/medical.json
+++ b/items/medical.json
@@ -3,7 +3,8 @@
     "id": "psionic_instability_remover",
     "name": { "str_sp": "morphic resilience cream" },
     "description": "An extremely thick cream that will \"enhance your resilience to the deleterious effects of XE037 overexposure\" if you rub it on your skin.  It smells like nail polish somehow gone rotten, and even touching it makes your fingertips itch terribly.",
-    "type": "COMESTIBLE",
+    "type": "ITEM",
+    "subtypes": ["COMESTIBLE"],
     "comestible_type": "MED",
     "weight": "265 g",
     "volume": "250 ml",
@@ -13,17 +14,18 @@
     "symbol": "q",
     "container": "bottle_plastic_small",
     "color": "blue",
-    "flags": [ "EATEN_COLD" ],
+    "flags": ["EATEN_COLD"],
     "phase": "solid",
     "use_action": {
       "type": "effect_on_conditions",
       "description": "Rub the cream on your skin.",
-      "effect_on_conditions": [ "EOC_INSTABILITY_CREAM" ]
+      "effect_on_conditions": ["EOC_INSTABILITY_CREAM"]
     }
   },
   {
     "id": "psionic_purifier_vita",
-    "type": "COMESTIBLE",
+    "type": "ITEM",
+    "subtypes": ["COMESTIBLE"],
     "comestible_type": "MED",
     "name": { "str_sp": "morphic reversion serum" },
     "description": "A faintly-glowing green liquid, the document you found told you that this would \"restore your morphology to baseline\", whatever that means.",
@@ -32,19 +34,20 @@
     "charges": 1,
     "price": "12 kUSD",
     "price_postapoc": "30 USD",
-    "material": [ "nether_crystal", "alien_liquid" ],
+    "material": ["nether_crystal", "alien_liquid"],
     "phase": "liquid",
     "container": "flask_glass",
     "symbol": "!",
     "color": "green",
-    "vitamins": [  ],
+    "vitamins": [],
     "healthy": -4,
-    "flags": [ "SINGLE_USE" ],
-    "use_action": [ "PURIFY_SMART" ]
+    "flags": ["SINGLE_USE"],
+    "use_action": ["PURIFY_SMART"]
   },
   {
     "id": "psi_noetic_resilience_treatment",
-    "type": "COMESTIBLE",
+    "type": "ITEM",
+    "subtypes": ["COMESTIBLE"],
     "comestible_type": "MED",
     "name": { "str_sp": "noetic resilience treatment" },
     "description": "A clear liquid, designed to alleviate some of the unpredictable effects of excessive psionic channeling.",
@@ -53,18 +56,18 @@
     "charges": 1,
     "price": "12 kUSD",
     "price_postapoc": "30 USD",
-    "material": [ "nether_crystal", "alien_liquid" ],
+    "material": ["nether_crystal", "alien_liquid"],
     "phase": "liquid",
     "container": "flask_glass",
     "symbol": "!",
     "color": "white",
-    "vitamins": [  ],
+    "vitamins": [],
     "healthy": -4,
-    "flags": [ "SINGLE_USE" ],
+    "flags": ["SINGLE_USE"],
     "use_action": {
       "type": "effect_on_conditions",
       "description": "Inject the concoction.",
-      "effect_on_conditions": [ "EOC_DRAIN_RESIST_POTION" ]
+      "effect_on_conditions": ["EOC_DRAIN_RESIST_POTION"]
     }
   }
 ]

--- a/items/misc.json
+++ b/items/misc.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "cards_zener",
-    "type": "GENERIC",
+    "type": "ITEM",
     "category": "other",
     "name": { "str": "deck of Zener cards", "str_pl": "decks of Zener cards" },
     "description": "A deck of Zener cards, used pre-Cataclysm to test for psychic ability.",
@@ -9,21 +9,25 @@
     "volume": "29 ml",
     "price": "13 USD 14 cent",
     "price_postapoc": "2 cent",
-    "material": [ "cardboard" ],
+    "material": ["cardboard"],
     "symbol": ",",
     "color": "magenta",
-    "flags": [ "NO_REPAIR" ],
+    "flags": ["NO_REPAIR"],
     "use_action": {
       "type": "effect_on_conditions",
       "description": "Pick a card.  Any card.",
-      "effect_on_conditions": [ "EOC_ZENER_DECK" ]
+      "effect_on_conditions": ["EOC_ZENER_DECK"]
     }
   },
   {
     "id": "force_field_generator",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "category": "other",
-    "name": { "str": "device labeled OS647-P", "str_pl": "devices labeled OS647-P" },
+    "name": {
+      "str": "device labeled OS647-P",
+      "str_pl": "devices labeled OS647-P"
+    },
     "description": "A small plastic device about the size of two smartphones stacked on top of each other, with a toggle on one end and \"OS647-P\" written prominently on one side above the XEDRA logo.  There is an indentation on the other side the right size to contain a matrix crystal.",
     "weight": "500 g",
     "volume": "200 ml",
@@ -37,14 +41,18 @@
     "use_action": {
       "type": "effect_on_conditions",
       "description": "Insert a black matrix crystal and flip the toggle.",
-      "effect_on_conditions": [ "EOC_FORCE_FIELD_GENERATOR_ACTIVATION" ]
+      "effect_on_conditions": ["EOC_FORCE_FIELD_GENERATOR_ACTIVATION"]
     }
   },
   {
     "id": "force_field_generator_broken",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "category": "other",
-    "name": { "str": "device labeled OS647-P", "str_pl": "devices labeled OS647-P" },
+    "name": {
+      "str": "device labeled OS647-P",
+      "str_pl": "devices labeled OS647-P"
+    },
     "description": "A small plastic device about the size of two smartphones stacked on top of each other, with a toggle on one end and \"OS647-P\" written prominently on one side above the XEDRA logo.  Parts of the device seem melted and the toggle no longer moves.",
     "weight": "496 g",
     "volume": "200 ml",
@@ -57,20 +65,20 @@
     "color": "dark_gray"
   },
   {
-    "type": "GENERIC",
+    "type": "ITEM",
     "id": "body_astral_projection",
     "copy-from": "corpse",
     "name": { "str_sp": "your body" },
     "description": "Your body, lying on the ground while your spirit walks free.  Hopefully nothing happens to it while you're gone.",
     "looks_like": "corpse_generic_human",
-    "material": [ "hflesh" ]
+    "material": ["hflesh"]
   },
   {
     "id": "skull_cougar",
-    "type": "GENERIC",
+    "type": "ITEM",
     "name": { "str": "cougar skull" },
     "description": "The skull of a cougar.",
-    "flags": [ "TRADER_AVOID" ],
+    "flags": ["TRADER_AVOID"],
     "category": "other",
     "weight": "450 g",
     "volume": "3 L",
@@ -78,7 +86,7 @@
     "color": "white",
     "price": "0 cent",
     "price_postapoc": "10 cent",
-    "material": [ "bone" ],
+    "material": ["bone"],
     "copy-from": "skull_abstract",
     "longest_side": "21 cm"
   }

--- a/items/psions_summon_items.json
+++ b/items/psions_summon_items.json
@@ -1,7 +1,8 @@
 [
   {
     "id": "biokin_breathe_skin_item",
-    "type": "TOOL_ARMOR",
+    "type": "ITEM",
+    "subtypes": ["TOOL", "ARMOR"],
     "name": { "str_sp": "[Ψ]oxygen absorption" },
     "description": "You are breathing through your skin.",
     "weight": "0 g",
@@ -24,11 +25,18 @@
       "NO_DROP"
     ],
     "environmental_protection": -5,
-    "armor": [ { "encumbrance": 0, "coverage": 0, "covers": [ "mouth", "head", "torso", "arm_l", "arm_r", "leg_l", "leg_r" ] } ]
+    "armor": [
+      {
+        "encumbrance": 0,
+        "coverage": 0,
+        "covers": ["mouth", "head", "torso", "arm_l", "arm_r", "leg_l", "leg_r"]
+      }
+    ]
   },
   {
     "id": "biokin_hammerhand_item",
-    "type": "TOOL_ARMOR",
+    "type": "ITEM",
+    "subtypes": ["TOOL", "ARMOR"],
     "name": { "str_sp": "[Ψ]hammerhand" },
     "description": "You can perform many common handy tasks with your bare hands.",
     "weight": "0 g",
@@ -50,21 +58,24 @@
       "NO_DROP"
     ],
     "qualities": [
-      [ "WRENCH", 1 ],
-      [ "SCREW", 1 ],
-      [ "HAMMER", 3 ],
-      [ "HAMMER_FINE", 1 ],
-      [ "HAMMER_SOFT", 1 ],
-      [ "CHISEL_WOOD", 1 ],
-      [ "PRYING_NAIL", 1 ],
-      [ "PRY", 2 ]
+      ["WRENCH", 1],
+      ["SCREW", 1],
+      ["HAMMER", 3],
+      ["HAMMER_FINE", 1],
+      ["HAMMER_SOFT", 1],
+      ["CHISEL_WOOD", 1],
+      ["PRYING_NAIL", 1],
+      ["PRY", 2]
     ],
-    "armor": [ { "encumbrance": 0, "coverage": 0, "covers": [ "hand_l", "hand_r" ] } ],
+    "armor": [
+      { "encumbrance": 0, "coverage": 0, "covers": ["hand_l", "hand_r"] }
+    ],
     "melee_damage": { "bash": 6 }
   },
   {
     "id": "clair_sense_rad_item",
-    "type": "ARMOR",
+    "type": "ITEM",
+    "subtypes": ["ARMOR"],
     "name": { "str": "[Ψ]radiation sense" },
     "description": "You can see ambient radiation as a faint, sinister glow.",
     "weight": "0 g",
@@ -73,11 +84,12 @@
     "price_postapoc": "0 cent",
     "symbol": "[",
     "color": "dark_gray",
-    "flags": [ "RAD_DETECT", "PERSONAL", "ZERO_WEIGHT" ]
+    "flags": ["RAD_DETECT", "PERSONAL", "ZERO_WEIGHT"]
   },
   {
     "id": "item_clair_astral_projection_cord",
-    "type": "TOOL_ARMOR",
+    "type": "ITEM",
+    "subtypes": ["TOOL", "ARMOR"],
     "name": { "str_sp": "[Ψ]silver cord" },
     "description": "A thin silver cord, stretching off into the distance, connecting you to your body.  You could follow it back to return.",
     "weight": "0 g",
@@ -102,7 +114,7 @@
   },
   {
     "id": "electro_robot_interface",
-    "type": "GENERIC",
+    "type": "ITEM",
     "name": { "str": "[Ψ]Robotic Interface" },
     "description": "Interface with robots remotely",
     "weight": "0 g",
@@ -125,11 +137,12 @@
       "INTEGRATED",
       "MAGICAL"
     ],
-    "use_action": [ "ROBOTCONTROL" ]
+    "use_action": ["ROBOTCONTROL"]
   },
   {
     "id": "electrokinetic_electrohack_1",
-    "type": "TOOL_ARMOR",
+    "type": "ITEM",
+    "subtypes": ["TOOL", "ARMOR"],
     "name": { "str": "[Ψ]hacking interface" },
     "description": "You can hack nearby devices.",
     "weight": "0 g",
@@ -152,43 +165,48 @@
       "INTEGRATED",
       "MAGICAL"
     ],
-    "qualities": [ [ "HACK", 0 ] ]
+    "qualities": [["HACK", 0]]
   },
   {
     "id": "electrokinetic_electrohack_2",
-    "type": "TOOL_ARMOR",
+    "type": "ITEM",
+    "subtypes": ["TOOL", "ARMOR"],
     "name": { "str": "[Ψ]hacking interface" },
     "description": "You can hack nearby devices.",
     "copy-from": "electrokinetic_electrohack_1",
-    "qualities": [ [ "HACK", 1 ] ]
+    "qualities": [["HACK", 1]]
   },
   {
     "id": "electrokinetic_electrohack_3",
-    "type": "TOOL_ARMOR",
+    "type": "ITEM",
+    "subtypes": ["TOOL", "ARMOR"],
     "name": { "str": "[Ψ]hacking interface" },
     "description": "You can hack nearby devices.",
     "copy-from": "electrokinetic_electrohack_1",
-    "qualities": [ [ "HACK", 2 ] ]
+    "qualities": [["HACK", 2]]
   },
   {
     "id": "electrokinetic_electrohack_4",
-    "type": "TOOL_ARMOR",
+    "type": "ITEM",
+    "subtypes": ["TOOL", "ARMOR"],
     "name": { "str": "[Ψ]hacking interface" },
     "description": "You can hack nearby devices.",
     "copy-from": "electrokinetic_electrohack_1",
-    "qualities": [ [ "HACK", 3 ] ]
+    "qualities": [["HACK", 3]]
   },
   {
     "id": "electrokinetic_electrohack_5",
-    "type": "TOOL_ARMOR",
+    "type": "ITEM",
+    "subtypes": ["TOOL", "ARMOR"],
     "name": { "str": "[Ψ]hacking interface" },
     "description": "You can hack nearby devices.",
     "copy-from": "electrokinetic_electrohack_1",
-    "qualities": [ [ "HACK", 4 ] ]
+    "qualities": [["HACK", 4]]
   },
   {
     "id": "item_photokinetic_radio",
-    "type": "TOOL_ARMOR",
+    "type": "ITEM",
+    "subtypes": ["TOOL", "ARMOR"],
     "name": { "str_sp": "[Ψ]radio sense (speaking)" },
     "description": "Your powers allow you to communicate by radio waves.  With a moment's concentration, you may instead scan for radio signals.",
     "weight": "0 g",
@@ -207,16 +225,30 @@
       "INTEGRATED",
       "PADDED"
     ],
-    "use_action": [ { "type": "transform", "target": "item_photokinetic_radio_on", "menu_text": "Switch to scanning mode" } ]
+    "use_action": [
+      {
+        "type": "transform",
+        "target": "item_photokinetic_radio_on",
+        "menu_text": "Switch to scanning mode"
+      }
+    ]
   },
   {
     "id": "item_photokinetic_radio_on",
     "copy-from": "item_photokinetic_radio",
-    "type": "TOOL_ARMOR",
+    "type": "ITEM",
+    "subtypes": ["TOOL", "ARMOR"],
     "name": { "str_sp": "[Ψ]radio sense (scanning)" },
     "description": "Your powers allow you to listen for radio signals from the surrounding area.  With a moment's concentration, you may change frequency or switch to communicating by radio.",
-    "use_action": [ "RADIO_ON", { "type": "transform", "target": "item_photokinetic_radio", "menu_text": "Switch to speaking mode" } ],
-    "tick_action": [ "RADIO_TICK" ],
+    "use_action": [
+      "RADIO_ON",
+      {
+        "type": "transform",
+        "target": "item_photokinetic_radio",
+        "menu_text": "Switch to speaking mode"
+      }
+    ],
+    "tick_action": ["RADIO_TICK"],
     "flags": [
       "TRADER_AVOID",
       "UNBREAKABLE",
@@ -231,16 +263,17 @@
   },
   {
     "id": "integrated_photo_eyes",
-    "type": "ARMOR",
+    "type": "ITEM",
+    "subtypes": ["ARMOR"],
     "category": "armor",
     "name": { "str_sp": "photon regulation" },
     "description": "With a little concentration, you can control the light your eyes accept.  Protects you from glare and welding arcs.",
     "weight": "1 g",
     "volume": "1 ml",
-    "material": [ "light" ],
+    "material": ["light"],
     "symbol": "[",
     "color": "yellow",
-    "qualities": [ [ "GLARE", 1 ] ],
+    "qualities": [["GLARE", 1]],
     "flags": [
       "INTEGRATED",
       "UNBREAKABLE",
@@ -254,8 +287,10 @@
     ],
     "armor": [
       {
-        "material": [ { "type": "light", "covered_by_mat": 100, "thickness": 0.1 } ],
-        "covers": [ "eyes" ],
+        "material": [
+          { "type": "light", "covered_by_mat": 100, "thickness": 0.1 }
+        ],
+        "covers": ["eyes"],
         "coverage": 100,
         "encumbrance": 0
       }
@@ -263,7 +298,8 @@
   },
   {
     "id": "pyrokinetic_fire_tool",
-    "type": "TOOL_ARMOR",
+    "type": "ITEM",
+    "subtypes": ["TOOL", "ARMOR"],
     "name": { "str_sp": "[Ψ]banked flames" },
     "description": "Dancing flames hovering over your hand.  You can use this to provide heat and light when necessary.",
     "weight": "0 g",
@@ -284,38 +320,47 @@
       "FIRE",
       "NO_DROP"
     ],
-    "qualities": [ [ "BLOW_HOT_AIR", 1 ] ],
-    "use_action": [ { "type": "firestarter", "moves": 30 }, { "type": "HOTPLATE" } ],
-    "armor": [ { "encumbrance": 25, "coverage": 0, "covers": [ "hand_l" ] } ],
-    "relic_data": { "passive_effects": [ { "id": "pyrokinetic_banked_fire_damage_enchant" } ] }
+    "qualities": [["BLOW_HOT_AIR", 1]],
+    "use_action": [
+      { "type": "firestarter", "moves": 30 },
+      { "type": "HOTPLATE" }
+    ],
+    "armor": [{ "encumbrance": 25, "coverage": 0, "covers": ["hand_l"] }],
+    "relic_data": {
+      "passive_effects": [{ "id": "pyrokinetic_banked_fire_damage_enchant" }]
+    }
   },
   {
     "id": "pyrokinetic_fire_tool_four_arms",
-    "type": "TOOL_ARMOR",
+    "type": "ITEM",
+    "subtypes": ["TOOL", "ARMOR"],
     "name": { "str_sp": "[Ψ]banked flames" },
     "copy-from": "pyrokinetic_fire_tool",
-    "armor": [ { "encumbrance": 12, "coverage": 0, "covers": [ "hand_l" ] } ],
-    "delete": { "flags": [ "RESTRICT_HANDS" ] }
+    "armor": [{ "encumbrance": 12, "coverage": 0, "covers": ["hand_l"] }],
+    "delete": { "flags": ["RESTRICT_HANDS"] }
   },
   {
     "id": "pyrokinetic_fire_tool_six_arms",
-    "type": "TOOL_ARMOR",
+    "type": "ITEM",
+    "subtypes": ["TOOL", "ARMOR"],
     "name": { "str_sp": "[Ψ]banked flames" },
     "copy-from": "pyrokinetic_fire_tool",
-    "armor": [ { "encumbrance": 8, "coverage": 0, "covers": [ "hand_l" ] } ],
-    "delete": { "flags": [ "RESTRICT_HANDS" ] }
+    "armor": [{ "encumbrance": 8, "coverage": 0, "covers": ["hand_l"] }],
+    "delete": { "flags": ["RESTRICT_HANDS"] }
   },
   {
     "id": "pyrokinetic_fire_tool_eight_arms",
-    "type": "TOOL_ARMOR",
+    "type": "ITEM",
+    "subtypes": ["TOOL", "ARMOR"],
     "name": { "str_sp": "[Ψ]banked flames" },
     "copy-from": "pyrokinetic_fire_tool",
-    "armor": [ { "encumbrance": 5, "coverage": 0, "covers": [ "hand_l" ] } ],
-    "delete": { "flags": [ "RESTRICT_HANDS" ] }
+    "armor": [{ "encumbrance": 5, "coverage": 0, "covers": ["hand_l"] }],
+    "delete": { "flags": ["RESTRICT_HANDS"] }
   },
   {
     "id": "pyrokinetic_torch_weld",
-    "type": "TOOL_ARMOR",
+    "type": "ITEM",
+    "subtypes": ["TOOL", "ARMOR"],
     "name": { "str": "[Ψ]incandescent lance" },
     "description": "A thin, searing beam, almost too bright to look at.  You can use this to weld or cut through things.",
     "weight": "0 g",
@@ -337,9 +382,14 @@
       "NO_UNLOAD",
       "NO_RELOAD"
     ],
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "noetic_charge_power": 1 } } ],
+    "pocket_data": [
+      {
+        "pocket_type": "MAGAZINE",
+        "ammo_restriction": { "noetic_charge_power": 1 }
+      }
+    ],
     "charges_per_use": 0,
-    "qualities": [ [ "WELD", 2 ] ],
+    "qualities": [["WELD", 2]],
     "use_action": [
       { "type": "firestarter", "moves": 10 },
       { "type": "OXYTORCH" },
@@ -373,22 +423,32 @@
         "move_cost": 500
       }
     ],
-    "armor": [ { "encumbrance": 0, "coverage": 0, "covers": [ "hand_l", "hand_r" ] } ]
+    "armor": [
+      { "encumbrance": 0, "coverage": 0, "covers": ["hand_l", "hand_r"] }
+    ]
   },
   {
     "id": "telekinetic_container_1",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]lifting field" },
     "description": "You can lift one thing with your powers, removing its effect on your encumbrance.",
     "weight": "0 g",
     "volume": "0 L",
     "price": "1 cent",
     "price_postapoc": "1 cent",
-    "material": [ "telekinetic_force" ],
+    "material": ["telekinetic_force"],
     "symbol": "[",
     "looks_like": "ragpouch",
     "color": "yellow",
-    "flags": [ "INTEGRATED", "UNBREAKABLE", "AURA", "NO_SALVAGE", "TARDIS", "ZERO_WEIGHT" ],
+    "flags": [
+      "INTEGRATED",
+      "UNBREAKABLE",
+      "AURA",
+      "NO_SALVAGE",
+      "TARDIS",
+      "ZERO_WEIGHT"
+    ],
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -405,18 +465,26 @@
   },
   {
     "id": "telekinetic_container_2",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]lifting field" },
     "description": "You can lift one thing with your powers, removing its effect on your encumbrance.",
     "weight": "0 g",
     "volume": "0 L",
     "price": "1 cent",
     "price_postapoc": "1 cent",
-    "material": [ "telekinetic_force" ],
+    "material": ["telekinetic_force"],
     "symbol": "[",
     "looks_like": "ragpouch",
     "color": "yellow",
-    "flags": [ "INTEGRATED", "UNBREAKABLE", "AURA", "NO_SALVAGE", "TARDIS", "ZERO_WEIGHT" ],
+    "flags": [
+      "INTEGRATED",
+      "UNBREAKABLE",
+      "AURA",
+      "NO_SALVAGE",
+      "TARDIS",
+      "ZERO_WEIGHT"
+    ],
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -433,18 +501,26 @@
   },
   {
     "id": "telekinetic_container_3",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]lifting field" },
     "description": "You can lift one thing with your powers, removing its effect on your encumbrance.",
     "weight": "0 g",
     "volume": "0 L",
     "price": "1 cent",
     "price_postapoc": "1 cent",
-    "material": [ "telekinetic_force" ],
+    "material": ["telekinetic_force"],
     "symbol": "[",
     "looks_like": "ragpouch",
     "color": "yellow",
-    "flags": [ "INTEGRATED", "UNBREAKABLE", "AURA", "NO_SALVAGE", "TARDIS", "ZERO_WEIGHT" ],
+    "flags": [
+      "INTEGRATED",
+      "UNBREAKABLE",
+      "AURA",
+      "NO_SALVAGE",
+      "TARDIS",
+      "ZERO_WEIGHT"
+    ],
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -461,18 +537,26 @@
   },
   {
     "id": "telekinetic_container_4",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]lifting field" },
     "description": "You can lift one thing with your powers, removing its effect on your encumbrance.",
     "weight": "0 g",
     "volume": "0 L",
     "price": "1 cent",
     "price_postapoc": "1 cent",
-    "material": [ "telekinetic_force" ],
+    "material": ["telekinetic_force"],
     "symbol": "[",
     "looks_like": "ragpouch",
     "color": "yellow",
-    "flags": [ "INTEGRATED", "UNBREAKABLE", "AURA", "NO_SALVAGE", "TARDIS", "ZERO_WEIGHT" ],
+    "flags": [
+      "INTEGRATED",
+      "UNBREAKABLE",
+      "AURA",
+      "NO_SALVAGE",
+      "TARDIS",
+      "ZERO_WEIGHT"
+    ],
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -489,18 +573,26 @@
   },
   {
     "id": "telekinetic_container_5",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]lifting field" },
     "description": "You can lift one thing with your powers, removing its effect on your encumbrance.",
     "weight": "0 g",
     "volume": "0 L",
     "price": "1 cent",
     "price_postapoc": "1 cent",
-    "material": [ "telekinetic_force" ],
+    "material": ["telekinetic_force"],
     "symbol": "[",
     "looks_like": "ragpouch",
     "color": "yellow",
-    "flags": [ "INTEGRATED", "UNBREAKABLE", "AURA", "NO_SALVAGE", "TARDIS", "ZERO_WEIGHT" ],
+    "flags": [
+      "INTEGRATED",
+      "UNBREAKABLE",
+      "AURA",
+      "NO_SALVAGE",
+      "TARDIS",
+      "ZERO_WEIGHT"
+    ],
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -517,18 +609,26 @@
   },
   {
     "id": "telekinetic_container_6",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]lifting field" },
     "description": "You can lift one thing with your powers, removing its effect on your encumbrance.",
     "weight": "0 g",
     "volume": "0 L",
     "price": "1 cent",
     "price_postapoc": "1 cent",
-    "material": [ "telekinetic_force" ],
+    "material": ["telekinetic_force"],
     "symbol": "[",
     "looks_like": "ragpouch",
     "color": "yellow",
-    "flags": [ "INTEGRATED", "UNBREAKABLE", "AURA", "NO_SALVAGE", "TARDIS", "ZERO_WEIGHT" ],
+    "flags": [
+      "INTEGRATED",
+      "UNBREAKABLE",
+      "AURA",
+      "NO_SALVAGE",
+      "TARDIS",
+      "ZERO_WEIGHT"
+    ],
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -545,18 +645,26 @@
   },
   {
     "id": "telekinetic_container_7",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]lifting field" },
     "description": "You can lift one thing with your powers, removing its effect on your encumbrance.",
     "weight": "0 g",
     "volume": "0 L",
     "price": "1 cent",
     "price_postapoc": "1 cent",
-    "material": [ "telekinetic_force" ],
+    "material": ["telekinetic_force"],
     "symbol": "[",
     "looks_like": "ragpouch",
     "color": "yellow",
-    "flags": [ "INTEGRATED", "UNBREAKABLE", "AURA", "NO_SALVAGE", "TARDIS", "ZERO_WEIGHT" ],
+    "flags": [
+      "INTEGRATED",
+      "UNBREAKABLE",
+      "AURA",
+      "NO_SALVAGE",
+      "TARDIS",
+      "ZERO_WEIGHT"
+    ],
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -573,18 +681,26 @@
   },
   {
     "id": "telekinetic_container_8",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]lifting field" },
     "description": "You can lift one thing with your powers, removing its effect on your encumbrance.",
     "weight": "0 g",
     "volume": "0 L",
     "price": "1 cent",
     "price_postapoc": "1 cent",
-    "material": [ "telekinetic_force" ],
+    "material": ["telekinetic_force"],
     "symbol": "[",
     "looks_like": "ragpouch",
     "color": "yellow",
-    "flags": [ "INTEGRATED", "UNBREAKABLE", "AURA", "NO_SALVAGE", "TARDIS", "ZERO_WEIGHT" ],
+    "flags": [
+      "INTEGRATED",
+      "UNBREAKABLE",
+      "AURA",
+      "NO_SALVAGE",
+      "TARDIS",
+      "ZERO_WEIGHT"
+    ],
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -601,18 +717,26 @@
   },
   {
     "id": "telekinetic_container_9",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]lifting field" },
     "description": "You can lift one thing with your powers, removing its effect on your encumbrance.",
     "weight": "0 g",
     "volume": "0 L",
     "price": "1 cent",
     "price_postapoc": "1 cent",
-    "material": [ "telekinetic_force" ],
+    "material": ["telekinetic_force"],
     "symbol": "[",
     "looks_like": "ragpouch",
     "color": "yellow",
-    "flags": [ "INTEGRATED", "UNBREAKABLE", "AURA", "NO_SALVAGE", "TARDIS", "ZERO_WEIGHT" ],
+    "flags": [
+      "INTEGRATED",
+      "UNBREAKABLE",
+      "AURA",
+      "NO_SALVAGE",
+      "TARDIS",
+      "ZERO_WEIGHT"
+    ],
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -629,18 +753,26 @@
   },
   {
     "id": "telekinetic_container_10",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]lifting field" },
     "description": "You can lift one thing with your powers, removing its effect on your encumbrance.",
     "weight": "0 g",
     "volume": "0 L",
     "price": "1 cent",
     "price_postapoc": "1 cent",
-    "material": [ "telekinetic_force" ],
+    "material": ["telekinetic_force"],
     "symbol": "[",
     "looks_like": "ragpouch",
     "color": "yellow",
-    "flags": [ "INTEGRATED", "UNBREAKABLE", "AURA", "NO_SALVAGE", "TARDIS", "ZERO_WEIGHT" ],
+    "flags": [
+      "INTEGRATED",
+      "UNBREAKABLE",
+      "AURA",
+      "NO_SALVAGE",
+      "TARDIS",
+      "ZERO_WEIGHT"
+    ],
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -657,18 +789,26 @@
   },
   {
     "id": "telekinetic_container_11",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]lifting field" },
     "description": "You can lift one thing with your powers, removing its effect on your encumbrance.",
     "weight": "0 g",
     "volume": "0 L",
     "price": "1 cent",
     "price_postapoc": "1 cent",
-    "material": [ "telekinetic_force" ],
+    "material": ["telekinetic_force"],
     "symbol": "[",
     "looks_like": "ragpouch",
     "color": "yellow",
-    "flags": [ "INTEGRATED", "UNBREAKABLE", "AURA", "NO_SALVAGE", "TARDIS", "ZERO_WEIGHT" ],
+    "flags": [
+      "INTEGRATED",
+      "UNBREAKABLE",
+      "AURA",
+      "NO_SALVAGE",
+      "TARDIS",
+      "ZERO_WEIGHT"
+    ],
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -685,18 +825,26 @@
   },
   {
     "id": "telekinetic_container_12",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]lifting field" },
     "description": "You can lift one thing with your powers, removing its effect on your encumbrance.",
     "weight": "0 g",
     "volume": "0 L",
     "price": "1 cent",
     "price_postapoc": "1 cent",
-    "material": [ "telekinetic_force" ],
+    "material": ["telekinetic_force"],
     "symbol": "[",
     "looks_like": "ragpouch",
     "color": "yellow",
-    "flags": [ "INTEGRATED", "UNBREAKABLE", "AURA", "NO_SALVAGE", "TARDIS", "ZERO_WEIGHT" ],
+    "flags": [
+      "INTEGRATED",
+      "UNBREAKABLE",
+      "AURA",
+      "NO_SALVAGE",
+      "TARDIS",
+      "ZERO_WEIGHT"
+    ],
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -713,18 +861,26 @@
   },
   {
     "id": "telekinetic_container_13",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]lifting field" },
     "description": "You can lift one thing with your powers, removing its effect on your encumbrance.",
     "weight": "0 g",
     "volume": "0 L",
     "price": "1 cent",
     "price_postapoc": "1 cent",
-    "material": [ "telekinetic_force" ],
+    "material": ["telekinetic_force"],
     "symbol": "[",
     "looks_like": "ragpouch",
     "color": "yellow",
-    "flags": [ "INTEGRATED", "UNBREAKABLE", "AURA", "NO_SALVAGE", "TARDIS", "ZERO_WEIGHT" ],
+    "flags": [
+      "INTEGRATED",
+      "UNBREAKABLE",
+      "AURA",
+      "NO_SALVAGE",
+      "TARDIS",
+      "ZERO_WEIGHT"
+    ],
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -741,18 +897,26 @@
   },
   {
     "id": "telekinetic_container_14",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]lifting field" },
     "description": "You can lift one thing with your powers, removing its effect on your encumbrance.",
     "weight": "0 g",
     "volume": "0 L",
     "price": "1 cent",
     "price_postapoc": "1 cent",
-    "material": [ "telekinetic_force" ],
+    "material": ["telekinetic_force"],
     "symbol": "[",
     "looks_like": "ragpouch",
     "color": "yellow",
-    "flags": [ "INTEGRATED", "UNBREAKABLE", "AURA", "NO_SALVAGE", "TARDIS", "ZERO_WEIGHT" ],
+    "flags": [
+      "INTEGRATED",
+      "UNBREAKABLE",
+      "AURA",
+      "NO_SALVAGE",
+      "TARDIS",
+      "ZERO_WEIGHT"
+    ],
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -769,18 +933,26 @@
   },
   {
     "id": "telekinetic_container_15",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]lifting field" },
     "description": "You can lift one thing with your powers, removing its effect on your encumbrance.",
     "weight": "0 g",
     "volume": "0 L",
     "price": "1 cent",
     "price_postapoc": "1 cent",
-    "material": [ "telekinetic_force" ],
+    "material": ["telekinetic_force"],
     "symbol": "[",
     "looks_like": "ragpouch",
     "color": "yellow",
-    "flags": [ "INTEGRATED", "UNBREAKABLE", "AURA", "NO_SALVAGE", "TARDIS", "ZERO_WEIGHT" ],
+    "flags": [
+      "INTEGRATED",
+      "UNBREAKABLE",
+      "AURA",
+      "NO_SALVAGE",
+      "TARDIS",
+      "ZERO_WEIGHT"
+    ],
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -797,18 +969,26 @@
   },
   {
     "id": "telekinetic_container_16",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]lifting field" },
     "description": "You can lift one thing with your powers, removing its effect on your encumbrance.",
     "weight": "0 g",
     "volume": "0 L",
     "price": "1 cent",
     "price_postapoc": "1 cent",
-    "material": [ "telekinetic_force" ],
+    "material": ["telekinetic_force"],
     "symbol": "[",
     "looks_like": "ragpouch",
     "color": "yellow",
-    "flags": [ "INTEGRATED", "UNBREAKABLE", "AURA", "NO_SALVAGE", "TARDIS", "ZERO_WEIGHT" ],
+    "flags": [
+      "INTEGRATED",
+      "UNBREAKABLE",
+      "AURA",
+      "NO_SALVAGE",
+      "TARDIS",
+      "ZERO_WEIGHT"
+    ],
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -825,18 +1005,26 @@
   },
   {
     "id": "telekinetic_container_17",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]lifting field" },
     "description": "You can lift one thing with your powers, removing its effect on your encumbrance.",
     "weight": "0 g",
     "volume": "0 L",
     "price": "1 cent",
     "price_postapoc": "1 cent",
-    "material": [ "telekinetic_force" ],
+    "material": ["telekinetic_force"],
     "symbol": "[",
     "looks_like": "ragpouch",
     "color": "yellow",
-    "flags": [ "INTEGRATED", "UNBREAKABLE", "AURA", "NO_SALVAGE", "TARDIS", "ZERO_WEIGHT" ],
+    "flags": [
+      "INTEGRATED",
+      "UNBREAKABLE",
+      "AURA",
+      "NO_SALVAGE",
+      "TARDIS",
+      "ZERO_WEIGHT"
+    ],
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -853,18 +1041,26 @@
   },
   {
     "id": "telekinetic_container_18",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]lifting field" },
     "description": "You can lift one thing with your powers, removing its effect on your encumbrance.",
     "weight": "0 g",
     "volume": "0 L",
     "price": "1 cent",
     "price_postapoc": "1 cent",
-    "material": [ "telekinetic_force" ],
+    "material": ["telekinetic_force"],
     "symbol": "[",
     "looks_like": "ragpouch",
     "color": "yellow",
-    "flags": [ "INTEGRATED", "UNBREAKABLE", "AURA", "NO_SALVAGE", "TARDIS", "ZERO_WEIGHT" ],
+    "flags": [
+      "INTEGRATED",
+      "UNBREAKABLE",
+      "AURA",
+      "NO_SALVAGE",
+      "TARDIS",
+      "ZERO_WEIGHT"
+    ],
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -881,18 +1077,26 @@
   },
   {
     "id": "telekinetic_container_19",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]lifting field" },
     "description": "You can lift one thing with your powers, removing its effect on your encumbrance.",
     "weight": "0 g",
     "volume": "0 L",
     "price": "1 cent",
     "price_postapoc": "1 cent",
-    "material": [ "telekinetic_force" ],
+    "material": ["telekinetic_force"],
     "symbol": "[",
     "looks_like": "ragpouch",
     "color": "yellow",
-    "flags": [ "INTEGRATED", "UNBREAKABLE", "AURA", "NO_SALVAGE", "TARDIS", "ZERO_WEIGHT" ],
+    "flags": [
+      "INTEGRATED",
+      "UNBREAKABLE",
+      "AURA",
+      "NO_SALVAGE",
+      "TARDIS",
+      "ZERO_WEIGHT"
+    ],
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -909,18 +1113,26 @@
   },
   {
     "id": "telekinetic_container_20",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]lifting field" },
     "description": "You can lift one thing with your powers, removing its effect on your encumbrance.",
     "weight": "0 g",
     "volume": "0 L",
     "price": "1 cent",
     "price_postapoc": "1 cent",
-    "material": [ "telekinetic_force" ],
+    "material": ["telekinetic_force"],
     "symbol": "[",
     "looks_like": "ragpouch",
     "color": "yellow",
-    "flags": [ "INTEGRATED", "UNBREAKABLE", "AURA", "NO_SALVAGE", "TARDIS", "ZERO_WEIGHT" ],
+    "flags": [
+      "INTEGRATED",
+      "UNBREAKABLE",
+      "AURA",
+      "NO_SALVAGE",
+      "TARDIS",
+      "ZERO_WEIGHT"
+    ],
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -937,18 +1149,26 @@
   },
   {
     "id": "telekinetic_container_21",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]lifting field" },
     "description": "You can lift one thing with your powers, removing its effect on your encumbrance.",
     "weight": "0 g",
     "volume": "0 L",
     "price": "1 cent",
     "price_postapoc": "1 cent",
-    "material": [ "telekinetic_force" ],
+    "material": ["telekinetic_force"],
     "symbol": "[",
     "looks_like": "ragpouch",
     "color": "yellow",
-    "flags": [ "INTEGRATED", "UNBREAKABLE", "AURA", "NO_SALVAGE", "TARDIS", "ZERO_WEIGHT" ],
+    "flags": [
+      "INTEGRATED",
+      "UNBREAKABLE",
+      "AURA",
+      "NO_SALVAGE",
+      "TARDIS",
+      "ZERO_WEIGHT"
+    ],
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -965,18 +1185,26 @@
   },
   {
     "id": "telekinetic_container_22",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]lifting field" },
     "description": "You can lift one thing with your powers, removing its effect on your encumbrance.",
     "weight": "0 g",
     "volume": "0 L",
     "price": "1 cent",
     "price_postapoc": "1 cent",
-    "material": [ "telekinetic_force" ],
+    "material": ["telekinetic_force"],
     "symbol": "[",
     "looks_like": "ragpouch",
     "color": "yellow",
-    "flags": [ "INTEGRATED", "UNBREAKABLE", "AURA", "NO_SALVAGE", "TARDIS", "ZERO_WEIGHT" ],
+    "flags": [
+      "INTEGRATED",
+      "UNBREAKABLE",
+      "AURA",
+      "NO_SALVAGE",
+      "TARDIS",
+      "ZERO_WEIGHT"
+    ],
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -993,18 +1221,26 @@
   },
   {
     "id": "telekinetic_container_23",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]lifting field" },
     "description": "You can lift one thing with your powers, removing its effect on your encumbrance.",
     "weight": "0 g",
     "volume": "0 L",
     "price": "1 cent",
     "price_postapoc": "1 cent",
-    "material": [ "telekinetic_force" ],
+    "material": ["telekinetic_force"],
     "symbol": "[",
     "looks_like": "ragpouch",
     "color": "yellow",
-    "flags": [ "INTEGRATED", "UNBREAKABLE", "AURA", "NO_SALVAGE", "TARDIS", "ZERO_WEIGHT" ],
+    "flags": [
+      "INTEGRATED",
+      "UNBREAKABLE",
+      "AURA",
+      "NO_SALVAGE",
+      "TARDIS",
+      "ZERO_WEIGHT"
+    ],
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -1021,18 +1257,26 @@
   },
   {
     "id": "telekinetic_container_24",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]lifting field" },
     "description": "You can lift one thing with your powers, removing its effect on your encumbrance.",
     "weight": "0 g",
     "volume": "0 L",
     "price": "1 cent",
     "price_postapoc": "1 cent",
-    "material": [ "telekinetic_force" ],
+    "material": ["telekinetic_force"],
     "symbol": "[",
     "looks_like": "ragpouch",
     "color": "yellow",
-    "flags": [ "INTEGRATED", "UNBREAKABLE", "AURA", "NO_SALVAGE", "TARDIS", "ZERO_WEIGHT" ],
+    "flags": [
+      "INTEGRATED",
+      "UNBREAKABLE",
+      "AURA",
+      "NO_SALVAGE",
+      "TARDIS",
+      "ZERO_WEIGHT"
+    ],
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -1049,18 +1293,26 @@
   },
   {
     "id": "telekinetic_container_25",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]lifting field" },
     "description": "You can lift one thing with your powers, removing its effect on your encumbrance.",
     "weight": "0 g",
     "volume": "0 L",
     "price": "1 cent",
     "price_postapoc": "1 cent",
-    "material": [ "telekinetic_force" ],
+    "material": ["telekinetic_force"],
     "symbol": "[",
     "looks_like": "ragpouch",
     "color": "yellow",
-    "flags": [ "INTEGRATED", "UNBREAKABLE", "AURA", "NO_SALVAGE", "TARDIS", "ZERO_WEIGHT" ],
+    "flags": [
+      "INTEGRATED",
+      "UNBREAKABLE",
+      "AURA",
+      "NO_SALVAGE",
+      "TARDIS",
+      "ZERO_WEIGHT"
+    ],
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -1077,18 +1329,26 @@
   },
   {
     "id": "telekinetic_container_26",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]lifting field" },
     "description": "You can lift one thing with your powers, removing its effect on your encumbrance.",
     "weight": "0 g",
     "volume": "0 L",
     "price": "1 cent",
     "price_postapoc": "1 cent",
-    "material": [ "telekinetic_force" ],
+    "material": ["telekinetic_force"],
     "symbol": "[",
     "looks_like": "ragpouch",
     "color": "yellow",
-    "flags": [ "INTEGRATED", "UNBREAKABLE", "AURA", "NO_SALVAGE", "TARDIS", "ZERO_WEIGHT" ],
+    "flags": [
+      "INTEGRATED",
+      "UNBREAKABLE",
+      "AURA",
+      "NO_SALVAGE",
+      "TARDIS",
+      "ZERO_WEIGHT"
+    ],
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -1105,18 +1365,26 @@
   },
   {
     "id": "telekinetic_container_27",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]lifting field" },
     "description": "You can lift one thing with your powers, removing its effect on your encumbrance.",
     "weight": "0 g",
     "volume": "0 L",
     "price": "1 cent",
     "price_postapoc": "1 cent",
-    "material": [ "telekinetic_force" ],
+    "material": ["telekinetic_force"],
     "symbol": "[",
     "looks_like": "ragpouch",
     "color": "yellow",
-    "flags": [ "INTEGRATED", "UNBREAKABLE", "AURA", "NO_SALVAGE", "TARDIS", "ZERO_WEIGHT" ],
+    "flags": [
+      "INTEGRATED",
+      "UNBREAKABLE",
+      "AURA",
+      "NO_SALVAGE",
+      "TARDIS",
+      "ZERO_WEIGHT"
+    ],
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -1133,18 +1401,26 @@
   },
   {
     "id": "telekinetic_container_28",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]lifting field" },
     "description": "You can lift one thing with your powers, removing its effect on your encumbrance.",
     "weight": "0 g",
     "volume": "0 L",
     "price": "1 cent",
     "price_postapoc": "1 cent",
-    "material": [ "telekinetic_force" ],
+    "material": ["telekinetic_force"],
     "symbol": "[",
     "looks_like": "ragpouch",
     "color": "yellow",
-    "flags": [ "INTEGRATED", "UNBREAKABLE", "AURA", "NO_SALVAGE", "TARDIS", "ZERO_WEIGHT" ],
+    "flags": [
+      "INTEGRATED",
+      "UNBREAKABLE",
+      "AURA",
+      "NO_SALVAGE",
+      "TARDIS",
+      "ZERO_WEIGHT"
+    ],
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -1161,18 +1437,26 @@
   },
   {
     "id": "telekinetic_container_29",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]lifting field" },
     "description": "You can lift one thing with your powers, removing its effect on your encumbrance.",
     "weight": "0 g",
     "volume": "0 L",
     "price": "1 cent",
     "price_postapoc": "1 cent",
-    "material": [ "telekinetic_force" ],
+    "material": ["telekinetic_force"],
     "symbol": "[",
     "looks_like": "ragpouch",
     "color": "yellow",
-    "flags": [ "INTEGRATED", "UNBREAKABLE", "AURA", "NO_SALVAGE", "TARDIS", "ZERO_WEIGHT" ],
+    "flags": [
+      "INTEGRATED",
+      "UNBREAKABLE",
+      "AURA",
+      "NO_SALVAGE",
+      "TARDIS",
+      "ZERO_WEIGHT"
+    ],
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -1189,18 +1473,26 @@
   },
   {
     "id": "telekinetic_container_30",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]lifting field" },
     "description": "You can lift one thing with your powers, removing its effect on your encumbrance.",
     "weight": "0 g",
     "volume": "0 L",
     "price": "1 cent",
     "price_postapoc": "1 cent",
-    "material": [ "telekinetic_force" ],
+    "material": ["telekinetic_force"],
     "symbol": "[",
     "looks_like": "ragpouch",
     "color": "yellow",
-    "flags": [ "INTEGRATED", "UNBREAKABLE", "AURA", "NO_SALVAGE", "TARDIS", "ZERO_WEIGHT" ],
+    "flags": [
+      "INTEGRATED",
+      "UNBREAKABLE",
+      "AURA",
+      "NO_SALVAGE",
+      "TARDIS",
+      "ZERO_WEIGHT"
+    ],
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -1218,172 +1510,252 @@
   {
     "id": "telekin_lifting_jack_1",
     "looks_like": "jack_makeshift",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]telekinetic jack" },
     "description": "Using your powers, you can lift up a vehicle just enough to allow you to change the wheels.",
-    "material": [ "telekinetic_force" ],
+    "material": ["telekinetic_force"],
     "symbol": ";",
     "color": "yellow",
     "weight": "0 g",
     "volume": "0 L",
-    "flags": [ "ZERO_WEIGHT", "INTEGRATED", "UNBREAKABLE", "PERSONAL" ],
-    "qualities": [ [ "JACK", 1 ], [ "LIFT", 1 ] ]
+    "flags": ["ZERO_WEIGHT", "INTEGRATED", "UNBREAKABLE", "PERSONAL"],
+    "qualities": [
+      ["JACK", 1],
+      ["LIFT", 1]
+    ]
   },
   {
     "id": "telekin_lifting_jack_2",
     "looks_like": "jack_makeshift",
     "copy-from": "telekin_lifting_jack_1",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]telekinetic jack" },
-    "qualities": [ [ "JACK", 2 ], [ "LIFT", 2 ] ]
+    "qualities": [
+      ["JACK", 2],
+      ["LIFT", 2]
+    ]
   },
   {
     "id": "telekin_lifting_jack_3",
     "looks_like": "jack_makeshift",
     "copy-from": "telekin_lifting_jack_1",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]telekinetic jack" },
-    "qualities": [ [ "JACK", 3 ], [ "LIFT", 3 ] ]
+    "qualities": [
+      ["JACK", 3],
+      ["LIFT", 3]
+    ]
   },
   {
     "id": "telekin_lifting_jack_4",
     "looks_like": "jack_makeshift",
     "copy-from": "telekin_lifting_jack_1",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]telekinetic jack" },
-    "qualities": [ [ "JACK", 4 ], [ "LIFT", 4 ] ]
+    "qualities": [
+      ["JACK", 4],
+      ["LIFT", 4]
+    ]
   },
   {
     "id": "telekin_lifting_jack_5",
     "looks_like": "jack_makeshift",
     "copy-from": "telekin_lifting_jack_1",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]telekinetic jack" },
-    "qualities": [ [ "JACK", 5 ], [ "LIFT", 5 ] ]
+    "qualities": [
+      ["JACK", 5],
+      ["LIFT", 5]
+    ]
   },
   {
     "id": "telekin_lifting_jack_6",
     "looks_like": "jack_makeshift",
     "copy-from": "telekin_lifting_jack_1",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]telekinetic jack" },
-    "qualities": [ [ "JACK", 6 ], [ "LIFT", 6 ] ]
+    "qualities": [
+      ["JACK", 6],
+      ["LIFT", 6]
+    ]
   },
   {
     "id": "telekin_lifting_jack_7",
     "looks_like": "jack_makeshift",
     "copy-from": "telekin_lifting_jack_1",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]telekinetic jack" },
-    "qualities": [ [ "JACK", 7 ], [ "LIFT", 7 ] ]
+    "qualities": [
+      ["JACK", 7],
+      ["LIFT", 7]
+    ]
   },
   {
     "id": "telekin_lifting_jack_8",
     "looks_like": "jack_makeshift",
     "copy-from": "telekin_lifting_jack_1",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]telekinetic jack" },
-    "qualities": [ [ "JACK", 8 ], [ "LIFT", 8 ] ]
+    "qualities": [
+      ["JACK", 8],
+      ["LIFT", 8]
+    ]
   },
   {
     "id": "telekin_lifting_jack_9",
     "looks_like": "jack_makeshift",
     "copy-from": "telekin_lifting_jack_1",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]telekinetic jack" },
-    "qualities": [ [ "JACK", 9 ], [ "LIFT", 9 ] ]
+    "qualities": [
+      ["JACK", 9],
+      ["LIFT", 9]
+    ]
   },
   {
     "id": "telekin_lifting_jack_10",
     "looks_like": "jack_makeshift",
     "copy-from": "telekin_lifting_jack_1",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]telekinetic jack" },
-    "qualities": [ [ "JACK", 10 ], [ "LIFT", 10 ] ]
+    "qualities": [
+      ["JACK", 10],
+      ["LIFT", 10]
+    ]
   },
   {
     "id": "telekin_lifting_jack_11",
     "looks_like": "jack_makeshift",
     "copy-from": "telekin_lifting_jack_1",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]telekinetic jack" },
-    "qualities": [ [ "JACK", 11 ], [ "LIFT", 11 ] ]
+    "qualities": [
+      ["JACK", 11],
+      ["LIFT", 11]
+    ]
   },
   {
     "id": "telekin_lifting_jack_12",
     "looks_like": "jack_makeshift",
     "copy-from": "telekin_lifting_jack_1",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]telekinetic jack" },
-    "qualities": [ [ "JACK", 12 ], [ "LIFT", 12 ] ]
+    "qualities": [
+      ["JACK", 12],
+      ["LIFT", 12]
+    ]
   },
   {
     "id": "telekin_lifting_jack_13",
     "looks_like": "jack_makeshift",
     "copy-from": "telekin_lifting_jack_1",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]telekinetic jack" },
-    "qualities": [ [ "JACK", 13 ], [ "LIFT", 13 ] ]
+    "qualities": [
+      ["JACK", 13],
+      ["LIFT", 13]
+    ]
   },
   {
     "id": "telekin_lifting_jack_14",
     "looks_like": "jack_makeshift",
     "copy-from": "telekin_lifting_jack_1",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]telekinetic jack" },
-    "qualities": [ [ "JACK", 14 ], [ "LIFT", 14 ] ]
+    "qualities": [
+      ["JACK", 14],
+      ["LIFT", 14]
+    ]
   },
   {
     "id": "telekin_lifting_jack_15",
     "looks_like": "jack_makeshift",
     "copy-from": "telekin_lifting_jack_1",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]telekinetic jack" },
-    "qualities": [ [ "JACK", 15 ], [ "LIFT", 15 ] ]
+    "qualities": [
+      ["JACK", 15],
+      ["LIFT", 15]
+    ]
   },
   {
     "id": "telekin_lifting_jack_16",
     "looks_like": "jack_makeshift",
     "copy-from": "telekin_lifting_jack_1",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]telekinetic jack" },
-    "qualities": [ [ "JACK", 16 ], [ "LIFT", 16 ] ]
+    "qualities": [
+      ["JACK", 16],
+      ["LIFT", 16]
+    ]
   },
   {
     "id": "telekin_lifting_jack_17",
     "looks_like": "jack_makeshift",
     "copy-from": "telekin_lifting_jack_1",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]telekinetic jack" },
-    "qualities": [ [ "JACK", 17 ], [ "LIFT", 17 ] ]
+    "qualities": [
+      ["JACK", 17],
+      ["LIFT", 17]
+    ]
   },
   {
     "id": "telekin_lifting_jack_18",
     "looks_like": "jack_makeshift",
     "copy-from": "telekin_lifting_jack_1",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]telekinetic jack" },
-    "qualities": [ [ "JACK", 18 ], [ "LIFT", 18 ] ]
+    "qualities": [
+      ["JACK", 18],
+      ["LIFT", 18]
+    ]
   },
   {
     "id": "telekin_lifting_jack_19",
     "looks_like": "jack_makeshift",
     "copy-from": "telekin_lifting_jack_1",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]telekinetic jack" },
-    "qualities": [ [ "JACK", 19 ], [ "LIFT", 19 ] ]
+    "qualities": [
+      ["JACK", 19],
+      ["LIFT", 19]
+    ]
   },
   {
     "id": "telekin_lifting_jack_20",
     "looks_like": "jack_makeshift",
     "copy-from": "telekin_lifting_jack_1",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "[Ψ]telekinetic jack" },
-    "qualities": [ [ "JACK", 20 ], [ "LIFT", 20 ] ]
+    "qualities": [
+      ["JACK", 20],
+      ["LIFT", 20]
+    ]
   },
   {
     "id": "vita_bandage_01",
-    "type": "GENERIC",
+    "type": "ITEM",
     "name": { "str": "[Ψ]Vitakinetic Wound Staunching" },
     "looks_like": "bandage",
     "description": "The power to stop bleeding",
@@ -1393,12 +1765,24 @@
     "price_postapoc": "1 cent",
     "symbol": "!",
     "color": "magenta",
-    "flags": [ "NO_INGEST", "EDIBLE_FROZEN", "ONLY_ONE", "ZERO_WEIGHT", "TRADER_AVOID", "SINGLE_USE" ],
-    "use_action": { "type": "heal", "bandages_power": 1, "bleed": 7, "move_cost": 0 }
+    "flags": [
+      "NO_INGEST",
+      "EDIBLE_FROZEN",
+      "ONLY_ONE",
+      "ZERO_WEIGHT",
+      "TRADER_AVOID",
+      "SINGLE_USE"
+    ],
+    "use_action": {
+      "type": "heal",
+      "bandages_power": 1,
+      "bleed": 7,
+      "move_cost": 0
+    }
   },
   {
     "id": "vita_bandages_02",
-    "type": "GENERIC",
+    "type": "ITEM",
     "name": { "str": "[Ψ]Vitakinetic Wound Staunching" },
     "looks_like": "bandage",
     "description": "The power to stop bleeding",
@@ -1408,12 +1792,24 @@
     "price_postapoc": "1 cent",
     "symbol": "!",
     "color": "magenta",
-    "flags": [ "NO_INGEST", "EDIBLE_FROZEN", "ONLY_ONE", "ZERO_WEIGHT", "TRADER_AVOID", "SINGLE_USE" ],
-    "use_action": { "type": "heal", "bandages_power": 2, "bleed": 14, "move_cost": 0 }
+    "flags": [
+      "NO_INGEST",
+      "EDIBLE_FROZEN",
+      "ONLY_ONE",
+      "ZERO_WEIGHT",
+      "TRADER_AVOID",
+      "SINGLE_USE"
+    ],
+    "use_action": {
+      "type": "heal",
+      "bandages_power": 2,
+      "bleed": 14,
+      "move_cost": 0
+    }
   },
   {
     "id": "vita_bandages_03",
-    "type": "GENERIC",
+    "type": "ITEM",
     "name": { "str": "[Ψ]Vitakinetic Wound Staunching" },
     "looks_like": "bandage",
     "description": "The power to stop bleeding",
@@ -1423,12 +1819,24 @@
     "price_postapoc": "1 cent",
     "symbol": "!",
     "color": "magenta",
-    "flags": [ "NO_INGEST", "EDIBLE_FROZEN", "ONLY_ONE", "ZERO_WEIGHT", "TRADER_AVOID", "SINGLE_USE" ],
-    "use_action": { "type": "heal", "bandages_power": 3, "bleed": 20, "move_cost": 0 }
+    "flags": [
+      "NO_INGEST",
+      "EDIBLE_FROZEN",
+      "ONLY_ONE",
+      "ZERO_WEIGHT",
+      "TRADER_AVOID",
+      "SINGLE_USE"
+    ],
+    "use_action": {
+      "type": "heal",
+      "bandages_power": 3,
+      "bleed": 20,
+      "move_cost": 0
+    }
   },
   {
     "id": "vita_disinfectant_01",
-    "type": "GENERIC",
+    "type": "ITEM",
     "name": { "str": "[Ψ]Vitakinetic Disinfectant" },
     "looks_like": "bandage",
     "description": "The power to stop infections",
@@ -1438,12 +1846,27 @@
     "price_postapoc": "1 cent",
     "symbol": "!",
     "color": "magenta",
-    "flags": [ "NO_INGEST", "EDIBLE_FROZEN", "ONLY_ONE", "ZERO_WEIGHT", "TRADER_AVOID", "SINGLE_USE" ],
-    "use_action": [ { "type": "heal", "bite": 0.5, "disinfectant_power": 1, "infect": 0.4, "move_cost": 0 } ]
+    "flags": [
+      "NO_INGEST",
+      "EDIBLE_FROZEN",
+      "ONLY_ONE",
+      "ZERO_WEIGHT",
+      "TRADER_AVOID",
+      "SINGLE_USE"
+    ],
+    "use_action": [
+      {
+        "type": "heal",
+        "bite": 0.5,
+        "disinfectant_power": 1,
+        "infect": 0.4,
+        "move_cost": 0
+      }
+    ]
   },
   {
     "id": "vita_disinfectant_02",
-    "type": "GENERIC",
+    "type": "ITEM",
     "name": { "str": "[Ψ]Vitakinetic Disinfectant" },
     "looks_like": "bandage",
     "description": "The power to stop infections",
@@ -1453,12 +1876,27 @@
     "price_postapoc": "1 cent",
     "symbol": "!",
     "color": "magenta",
-    "flags": [ "NO_INGEST", "EDIBLE_FROZEN", "ONLY_ONE", "ZERO_WEIGHT", "TRADER_AVOID", "SINGLE_USE" ],
-    "use_action": [ { "type": "heal", "bite": 0.7, "disinfectant_power": 2, "infect": 0.6, "move_cost": 0 } ]
+    "flags": [
+      "NO_INGEST",
+      "EDIBLE_FROZEN",
+      "ONLY_ONE",
+      "ZERO_WEIGHT",
+      "TRADER_AVOID",
+      "SINGLE_USE"
+    ],
+    "use_action": [
+      {
+        "type": "heal",
+        "bite": 0.7,
+        "disinfectant_power": 2,
+        "infect": 0.6,
+        "move_cost": 0
+      }
+    ]
   },
   {
     "id": "vita_disinfectant_03",
-    "type": "GENERIC",
+    "type": "ITEM",
     "name": { "str": "[Ψ]Vitakinetic Disinfectant" },
     "looks_like": "bandage",
     "description": "The power to stop infections",
@@ -1468,7 +1906,22 @@
     "price_postapoc": "1 cent",
     "symbol": "!",
     "color": "magenta",
-    "flags": [ "NO_INGEST", "EDIBLE_FROZEN", "ONLY_ONE", "ZERO_WEIGHT", "TRADER_AVOID", "SINGLE_USE" ],
-    "use_action": [ { "type": "heal", "bite": 0.9, "disinfectant_power": 3, "infect": 0.8, "move_cost": 0 } ]
+    "flags": [
+      "NO_INGEST",
+      "EDIBLE_FROZEN",
+      "ONLY_ONE",
+      "ZERO_WEIGHT",
+      "TRADER_AVOID",
+      "SINGLE_USE"
+    ],
+    "use_action": [
+      {
+        "type": "heal",
+        "bite": 0.9,
+        "disinfectant_power": 3,
+        "infect": 0.8,
+        "move_cost": 0
+      }
+    ]
   }
 ]

--- a/items/schematics.json
+++ b/items/schematics.json
@@ -1,7 +1,8 @@
 [
   {
     "id": "schematics_matrix_channeling",
-    "type": "BOOK",
+    "type": "ITEM",
+    "subtypes": ["BOOK"],
     "name": { "str_sp": "matrix channeling array schematics" },
     "description": "This is a series of technical design documents for a \"matrix channeling array\" designed to \"allow an attuned mathematician to direct a stronger level of Netherum energy\".  It sounds like nonsense, but the document does have the XEDRA seal stamped on it.",
     "copy-from": "schematics_generic",
@@ -15,7 +16,8 @@
   },
   {
     "id": "schematics_matrix_aligning",
-    "type": "BOOK",
+    "type": "ITEM",
+    "subtypes": ["BOOK"],
     "name": { "str_sp": "crystalline focusing assembly schematics" },
     "description": "This is a series of technical design documents for a focusing assembly designed to \"enhance the precision of Netherum mathematics\".",
     "copy-from": "schematics_generic",
@@ -29,7 +31,8 @@
   },
   {
     "id": "schematics_telepathic_focusing_tool",
-    "type": "BOOK",
+    "type": "ITEM",
+    "subtypes": ["BOOK"],
     "name": { "str_sp": "telepathic focusing tool schematics" },
     "description": "This is a series of technical design documents for a focusing assembly designed to \"enhance the precision of Netherum mathematics\".",
     "copy-from": "schematics_generic",
@@ -43,7 +46,8 @@
   },
   {
     "id": "schematics_matrix_crystal_ground",
-    "type": "BOOK",
+    "type": "ITEM",
+    "subtypes": ["BOOK"],
     "name": { "str_sp": "refined matrix crystal schematics" },
     "description": "A series of technical documents for further refining ground matrix crystal, separating out the inert parts from the \"Netherically active\" parts.",
     "copy-from": "schematics_generic",
@@ -57,7 +61,8 @@
   },
   {
     "id": "schematics_anchoring_crown",
-    "type": "BOOK",
+    "type": "ITEM",
+    "subtypes": ["BOOK"],
     "name": { "str_sp": "anchoring crown schematics" },
     "description": "This is a series of technical design documents for using matrix crystals to shield the wearer from excess Netherum energies with the drawback of also shutting down any psionic ability they have while worn.",
     "copy-from": "schematics_generic",
@@ -71,7 +76,8 @@
   },
   {
     "id": "schematics_telepathic_dampener",
-    "type": "BOOK",
+    "type": "ITEM",
+    "subtypes": ["BOOK"],
     "name": { "str_sp": "telepathic dampener schematics" },
     "description": "This is a series of technical design documents for using matrix crystals to shield the wearer's mind from telepathic assault and from unfriendly attention from Netherum entities.  The design also mentions that it reduces the wearer's own psionic power, however.",
     "copy-from": "schematics_generic",
@@ -85,7 +91,8 @@
   },
   {
     "id": "schematics_grenade_inferno",
-    "type": "BOOK",
+    "type": "ITEM",
+    "subtypes": ["BOOK"],
     "name": { "str_sp": "inferno grenade schematics" },
     "description": "This is a design document to create a grenade using matrix crystal dust that explodes in a sea of pure flame.  In pen below is the note \"EXTREMELY DANGEROUS\".  You're not sure you could replicate the exact process with the tools available to you, but you could definitely come up with your own version.",
     "copy-from": "schematics_generic",
@@ -99,7 +106,8 @@
   },
   {
     "id": "schematics_transporters",
-    "type": "BOOK",
+    "type": "ITEM",
+    "subtypes": ["BOOK"],
     "name": { "str_sp": "Netherum transporter schematics" },
     "description": "This is a series of design documents for building a transporter beacon and connected transporter remote, which you can use to teleport yourself through the Nether to the beacon.  It's labeled \"for immersion use only\", but that part has a line through it and \"IT WORKS!\" written next to it in pen.  There's another note in red that states that on very rare occasions, \"entities\" can also use the beacon to exit the Nether, and also that as of two weeks before the Cataclysm, the designers have not solved the energy surge problems that make each remote burn out after use.",
     "copy-from": "schematics_generic",
@@ -113,7 +121,8 @@
   },
   {
     "id": "schematics_everglow_lamp",
-    "type": "BOOK",
+    "type": "ITEM",
+    "subtypes": ["BOOK"],
     "name": { "str_sp": "everglow matrix lamp schematics" },
     "description": "This is a series of design documents to use ground matrix crystals to greatly enhance the power efficiency of a lamp.",
     "copy-from": "schematics_generic",
@@ -127,7 +136,8 @@
   },
   {
     "id": "schematics_reactant_liquid_base",
-    "type": "BOOK",
+    "type": "ITEM",
+    "subtypes": ["BOOK"],
     "name": { "str_sp": "psychoreactive catalyst specifications" },
     "description": "A chemical formula for mixing ground matrix crystals with other metals and dissolving them in liquid.  There's a long list of possible applications for the resulting compound, almost all of which would have seemed like pure fantasy if you hadn't lived through the end of the world.",
     "copy-from": "schematics_generic",
@@ -141,7 +151,8 @@
   },
   {
     "id": "schematics_instability_remover",
-    "type": "BOOK",
+    "type": "ITEM",
+    "subtypes": ["BOOK"],
     "name": { "str_sp": "morphic reinforcement serum schematics" },
     "description": "This document details a series of steps for making an injectable serum which will \"enhance the subject's resilience against detrimental mutagenic alterations caused by XE037 overexposure, reducing negative outcomes during testing\".  It's stamped with a XEDRA symbol in the corner with \"Project PHAVIAN\" written at the top.",
     "copy-from": "schematics_generic",
@@ -155,7 +166,8 @@
   },
   {
     "id": "schematics_psionic_purifier",
-    "type": "BOOK",
+    "type": "ITEM",
+    "subtypes": ["BOOK"],
     "name": { "str_sp": "morphic reversion serum schematics" },
     "description": "A series of steps to create a serum that will \"Eliminate the undesirable effects of XE037 overexposure\".  It is designed to be injected in the recipient.",
     "copy-from": "schematics_generic",
@@ -169,7 +181,8 @@
   },
   {
     "id": "schematics_noetic_resilience",
-    "type": "BOOK",
+    "type": "ITEM",
+    "subtypes": ["BOOK"],
     "name": { "str_sp": "noetic resilience treatment schematics" },
     "description": "A technical document outlining a treatment for \"noetic overuse\".  After the outline of the treatment is a note, dated two weeks before the end of the world, that while it showed great promise in initial trials the side effects require further study before it can be recommended for widespread usage.",
     "copy-from": "schematics_generic",
@@ -182,7 +195,8 @@
     "color": "white"
   },
   {
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "id": "psi_usb_rad_recipes",
     "symbol": ",",
     "color": "white",
@@ -190,20 +204,26 @@
     "description": "A USB thumb drive with the XEDRA logo over a large Ψ symbol printed on it.  You'd bet there's something important on here.",
     "price": "12 USD",
     "price_postapoc": "10 cent",
-    "material": [ "plastic", "aluminum" ],
+    "material": ["plastic", "aluminum"],
     "weight": "4536 mg",
     "volume": "4 ml",
     "longest_side": "5 cm",
-    "to_hit": { "grip": "bad", "length": "hand", "surface": "any", "balance": "clumsy" },
+    "to_hit": {
+      "grip": "bad",
+      "length": "hand",
+      "surface": "any",
+      "balance": "clumsy"
+    },
     "use_action": {
       "type": "effect_on_conditions",
       "description": "Use a laptop to access the data.",
-      "effect_on_conditions": [ "EOC_PSI_USB_RAD_RECIPE" ]
+      "effect_on_conditions": ["EOC_PSI_USB_RAD_RECIPE"]
     }
   },
   {
     "id": "phavian_noetic_resonance_detector_instructions",
-    "type": "BOOK",
+    "type": "ITEM",
+    "subtypes": ["BOOK"],
     "name": { "str_sp": "noetic resonance detector operator instructions" },
     "description": "An extensive series of instructions on the proper calibrations and parameters for using the \"noetic resonance detector\" to determine a target's noetic potential.  There is no way you could have ever figured this out without these directions to follow.",
     "copy-from": "schematics_generic",

--- a/items/survivor_recipes.json
+++ b/items/survivor_recipes.json
@@ -1,7 +1,8 @@
 [
   {
     "id": "recipe_survivor_matrix_crystal_ground",
-    "type": "BOOK",
+    "type": "ITEM",
+    "subtypes": ["BOOK"],
     "name": { "str_sp": "scribbled matrix crystal notes" },
     "description": "A series of notes, musings, and marginalia about grinding up matrix crystals, refining the dust and then…mixing it with water and drinking the results?  Hopefully it won't make you go blind.",
     "copy-from": "file",

--- a/items/tools/crafting_tools.json
+++ b/items/tools/crafting_tools.json
@@ -1,7 +1,8 @@
 [
   {
     "id": "matrix_channeling_tool",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "matrix channeling array" },
     "description": "A set of matrix crystals arranged together to direct Netherium energy.  You're not entirely sure all the crystals are actually touching the metal assembly soldered around them.",
     "weight": "2500 g",
@@ -11,15 +12,19 @@
     "price_postapoc": "50 cent",
     "to_hit": -2,
     "melee_damage": { "bash": 2 },
-    "material": [ "nether_crystal", "steel" ],
+    "material": ["nether_crystal", "steel"],
     "symbol": "[",
     "color": "white",
-    "qualities": [ [ "MATRIX_CHANNEL", 1 ] ]
+    "qualities": [["MATRIX_CHANNEL", 1]]
   },
   {
     "id": "matrix_aligning_tool",
-    "type": "TOOL",
-    "name": { "str": "crystalline focusing assembly", "str_pl": "crystalline focusing assemblies" },
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
+    "name": {
+      "str": "crystalline focusing assembly",
+      "str_pl": "crystalline focusing assemblies"
+    },
     "description": "A precise arrangement of cut crystal pieces from the crystal outgrowths left by the portal storms.  The air in the center shimmers like a summer heat gaze when you look through the focal point of the apparatus.",
     "weight": "4000 g",
     "volume": "750 ml",
@@ -28,15 +33,19 @@
     "price_postapoc": "40 cent",
     "to_hit": -2,
     "melee_damage": { "bash": 5 },
-    "material": [ "nether_crystal", "steel" ],
+    "material": ["nether_crystal", "steel"],
     "symbol": "[",
     "color": "light_gray",
-    "qualities": [ [ "MATRIX_FOCUS", 1 ] ]
+    "qualities": [["MATRIX_FOCUS", 1]]
   },
   {
     "id": "telepathic_focusing_tool",
-    "type": "TOOL",
-    "name": { "str": "telepathic focusing tool", "str_pl": "telepathic focusing assemblies" },
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
+    "name": {
+      "str": "telepathic focusing tool",
+      "str_pl": "telepathic focusing assemblies"
+    },
     "description": "A glowing white netherium crystal surrounded by floating dust and shards of crystal.  The closer you look at the assembly the louder your thoughts sound.",
     "weight": "4000 g",
     "volume": "750 ml",
@@ -44,7 +53,7 @@
     "price": "30 USD",
     "price_postapoc": "40 cent",
     "melee_damage": { "bash": 5 },
-    "material": [ "nether_crystal", "steel" ],
+    "material": ["nether_crystal", "steel"],
     "symbol": "[",
     "color": "light_gray"
   }

--- a/items/tools/lighting.json
+++ b/items/tools/lighting.json
@@ -1,10 +1,14 @@
 [
   {
     "id": "pyrokinetic_flashlight",
-    "type": "TOOL",
-    "name": { "str": "everglow matrix flashlight (off)", "str_pl": "everglow matrix flashlights (off)" },
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
+    "name": {
+      "str": "everglow matrix flashlight (off)",
+      "str_pl": "everglow matrix flashlights (off)"
+    },
     "description": "A household flashlight enhanced with matrix technology.  It is slightly dimmer but will last significantly longer.",
-    "material": [ "plastic", "aluminum", "nether_crystal" ],
+    "material": ["plastic", "aluminum", "nether_crystal"],
     "symbol": ";",
     "color": "blue",
     "weight": "280 g",
@@ -13,8 +17,8 @@
     "price": "15 USD",
     "price_postapoc": "5 USD",
     "charges_per_use": 1,
-    "tool_ammo": [ "battery" ],
-    "flags": [ "BELT_CLIP", "WATER_BREAK_ACTIVE" ],
+    "tool_ammo": ["battery"],
+    "flags": ["BELT_CLIP", "WATER_BREAK_ACTIVE"],
     "use_action": {
       "type": "transform",
       "msg": "You turn the flashlight on.",
@@ -27,7 +31,7 @@
       {
         "pocket_type": "MAGAZINE_WELL",
         "rigid": true,
-        "flag_restriction": [ "BATTERY_LIGHT", "BATTERY_ULTRA_LIGHT" ],
+        "flag_restriction": ["BATTERY_LIGHT", "BATTERY_ULTRA_LIGHT"],
         "default_magazine": "light_disposable_cell"
       }
     ]
@@ -35,8 +39,12 @@
   {
     "id": "pyrokinetic_flashlight_on",
     "copy-from": "pyrokinetic_flashlight",
-    "type": "TOOL",
-    "name": { "str": "everglow matrix flashlight (on)", "str_pl": "everglow matrix flashlights (on)" },
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
+    "name": {
+      "str": "everglow matrix flashlight (on)",
+      "str_pl": "everglow matrix flashlights (on)"
+    },
     "power_draw": "2 W",
     "revert_to": "pyrokinetic_flashlight",
     "use_action": {
@@ -46,12 +54,22 @@
       "target": "pyrokinetic_flashlight",
       "ammo_scale": 0
     },
-    "flags": [ "LIGHT_225", "CHARGEDIM", "TRADER_AVOID", "BELT_CLIP", "WATER_BREAK" ]
+    "flags": [
+      "LIGHT_225",
+      "CHARGEDIM",
+      "TRADER_AVOID",
+      "BELT_CLIP",
+      "WATER_BREAK"
+    ]
   },
   {
     "id": "pyrokinetic_lamp",
-    "type": "TOOL",
-    "name": { "str": "everglow matrix lamp (covered)", "str_pl": "everglow matrix lamps (covered)" },
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
+    "name": {
+      "str": "everglow matrix lamp (covered)",
+      "str_pl": "everglow matrix lamps (covered)"
+    },
     "description": "Powered by matrix technology, this lamp will shed a reddish light for far longer than a standard battery-powered lamp.  Activate to open the lid.",
     "weight": "1438 g",
     "volume": "1 L",
@@ -59,7 +77,7 @@
     "price_postapoc": "40 USD",
     "to_hit": -2,
     "melee_damage": { "bash": 8 },
-    "material": [ "plastic", "aluminum", "nether_crystal" ],
+    "material": ["plastic", "aluminum", "nether_crystal"],
     "symbol": ",",
     "color": "red",
     "use_action": {
@@ -75,30 +93,46 @@
       {
         "pocket_type": "MAGAZINE_WELL",
         "rigid": true,
-        "flag_restriction": [ "BATTERY_LIGHT", "BATTERY_ULTRA_LIGHT" ],
+        "flag_restriction": ["BATTERY_LIGHT", "BATTERY_ULTRA_LIGHT"],
         "default_magazine": "light_disposable_cell"
       }
     ],
-    "flags": [ "LEAK_DAM", "ALLOWS_REMOTE_USE", "WATER_BREAK_ACTIVE" ]
+    "flags": ["LEAK_DAM", "ALLOWS_REMOTE_USE", "WATER_BREAK_ACTIVE"]
   },
   {
     "id": "pyrokinetic_lamp_on",
-    "type": "TOOL",
-    "name": { "str": "everglow matrix lamp (uncovered)", "str_pl": "everglow matrix lamps (uncovered)" },
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
+    "name": {
+      "str": "everglow matrix lamp (uncovered)",
+      "str_pl": "everglow matrix lamps (uncovered)"
+    },
     "copy-from": "pyrokinetic_lamp",
     "description": "Powered by matrix technology, this lamp will shed a reddish light for far longer than a standard battery-powered lamp.  Activate to close the lid.",
     "power_draw": "2 W",
-    "use_action": { "type": "transform", "target": "pyrokinetic_lamp", "msg": "You close the lamp's cover.", "menu_text": "Close cover" },
-    "flags": [ "LIGHT_150", "LEAK_DAM", "ALLOWS_REMOTE_USE", "CHARGEDIM", "TRADER_AVOID", "WATER_BREAK" ]
+    "use_action": {
+      "type": "transform",
+      "target": "pyrokinetic_lamp",
+      "msg": "You close the lamp's cover.",
+      "menu_text": "Close cover"
+    },
+    "flags": [
+      "LIGHT_150",
+      "LEAK_DAM",
+      "ALLOWS_REMOTE_USE",
+      "CHARGEDIM",
+      "TRADER_AVOID",
+      "WATER_BREAK"
+    ]
   },
   {
-    "type": "GENERIC",
+    "type": "ITEM",
     "id": "standing_pyrokinetic_lamp",
     "name": { "str": "disconnected standing matrix lamp" },
     "description": "A tall floor lamp that provides illumination when plugged into a power outlet.  This lamp is enhanced with matrix technology.",
     "weight": "2500 g",
     "to_hit": -1,
-    "material": [ "plastic", "steel" ],
+    "material": ["plastic", "steel"],
     "volume": "2 L",
     "longest_side": "170 cm",
     "melee_damage": { "bash": 5 },

--- a/items/tools/nether_items.json
+++ b/items/tools/nether_items.json
@@ -1,18 +1,19 @@
 [
   {
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "id": "chaos_stone",
     "name": { "str_sp": "compressed chaos" },
     "color": "magenta",
     "use_action": {
       "type": "effect_on_conditions",
       "description": "Seems like chaos in solid form.",
-      "effect_on_conditions": [ "EOC_CAUSE_PORTAL_STORM" ]
+      "effect_on_conditions": ["EOC_CAUSE_PORTAL_STORM"]
     },
     "volume": "250 ml",
     "weight": "10 g",
     "symbol": "@",
     "description": "This defies easy description, it feels solid but the surface is yielding.  Looking at it you are reminded of the electric tingle in the air before a portal storm.",
-    "flags": [ "SINGLE_USE" ]
+    "flags": ["SINGLE_USE"]
   }
 ]

--- a/items/tools/pseudo.json
+++ b/items/tools/pseudo.json
@@ -1,13 +1,14 @@
 [
   {
     "id": "black_nether_crystal_pseudo_tool",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "nether crystal outcropping" },
     "description": "This is the pseudo-tool provided by having a nearby cluster of black nether crystal.  You shouldn't see this as an individual item.",
     "symbol": "O",
     "color": "red",
     "weight": "0 g",
     "volume": "0 ml",
-    "flags": [ "ZERO_WEIGHT" ]
+    "flags": ["ZERO_WEIGHT"]
   }
 ]

--- a/items/tools/travel.json
+++ b/items/tools/travel.json
@@ -1,7 +1,8 @@
 [
   {
     "id": "psionic_transporter_beacon",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "transporter beacon" },
     "description": "A pyramidal object with a matrix crystal on top, surrounded by several chunks of the otherworldly boulders you've found dotting the landscape.  You could place it somewhere and after you've configured it, use a transporter remote to teleport yourself to its location.",
     "weight": "2500 g",
@@ -18,7 +19,8 @@
   },
   {
     "id": "psionic_transporter_remote",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str": "transporter remote" },
     "description": "A blocky item, like an old feature cellphone crossed with a radio.  A matrix channeling array is stick out of the side like an antenna.  There is a small screen on the front, currently off.",
     "weight": "500 g",
@@ -34,7 +36,7 @@
     "price_postapoc": "1 USD",
     "symbol": ";",
     "color": "blue",
-    "tool_ammo": [ "battery" ],
+    "tool_ammo": ["battery"],
     "charges_per_use": 1,
     "use_action": {
       "target": "psionic_transporter_remote_on",
@@ -44,30 +46,35 @@
       "need_charges_msg": "The transporter remote's batteries need more charge.",
       "type": "transform"
     },
-    "flags": [ "WATER_BREAK", "ELECTRONIC" ],
+    "flags": ["WATER_BREAK", "ELECTRONIC"],
     "pocket_data": [
       {
         "pocket_type": "MAGAZINE_WELL",
         "rigid": true,
-        "flag_restriction": [ "BATTERY_LIGHT", "BATTERY_ULTRA_LIGHT" ],
+        "flag_restriction": ["BATTERY_LIGHT", "BATTERY_ULTRA_LIGHT"],
         "default_magazine": "light_plus_battery_cell"
       }
     ]
   },
   {
     "id": "psionic_transporter_remote_on",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str_sp": "transporter remote (searching)" },
     "description": "A blocky item, like an old feature cellphone crossed with a radio.  A matrix channeling array is sticking out of the side like an antenna.  There is a small screen on the front, currently running what looks like a series of mathematical calculations.",
     "weight": "500 g",
     "volume": "350 ml",
     "longest_side": "15 cm",
-    "material": [ { "type": "plastic", "portion": 85 }, { "type": "steel", "portion": 10 }, { "type": "nether_crystal", "portion": 5 } ],
+    "material": [
+      { "type": "plastic", "portion": 85 },
+      { "type": "steel", "portion": 10 },
+      { "type": "nether_crystal", "portion": 5 }
+    ],
     "price": "90 USD",
     "price_postapoc": "1 USD",
     "symbol": ";",
     "color": "blue",
-    "tool_ammo": [ "battery" ],
+    "tool_ammo": ["battery"],
     "charges_per_use": 1,
     "use_action": [
       {
@@ -82,15 +89,15 @@
         "menu_text": "Activate the remote",
         "description": "Begin the transportation process.  It will take several minutes for the remote to zero in on the beacon location.",
         "//need_charges_msg": "The transporter remote's charge is too low.",
-        "effect_on_conditions": [ "EOC_PSI_TRANSPORTER_REMOTE_TELEPORT" ]
+        "effect_on_conditions": ["EOC_PSI_TRANSPORTER_REMOTE_TELEPORT"]
       }
     ],
-    "flags": [ "TRADER_AVOID", "WATER_BREAK", "ELECTRONIC" ],
+    "flags": ["TRADER_AVOID", "WATER_BREAK", "ELECTRONIC"],
     "pocket_data": [
       {
         "pocket_type": "MAGAZINE_WELL",
         "rigid": true,
-        "flag_restriction": [ "BATTERY_LIGHT", "BATTERY_ULTRA_LIGHT" ],
+        "flag_restriction": ["BATTERY_LIGHT", "BATTERY_ULTRA_LIGHT"],
         "default_magazine": "light_plus_battery_cell"
       }
     ],
@@ -100,12 +107,13 @@
   },
   {
     "id": "psionic_transporter_remote_broken",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "name": { "str_sp": "transporter remote (burned out)" },
     "description": "A blocky item, like an old feature cellphone crossed with a radio.  A matrix channeling array was sticking out of the side like an antenna, but it's now cracked and probably useless.  There is a small screen on the front, obviously burned out.  Parts of the plastic casing are warped as though the plastic had frozen and cracked.",
     "copy-from": "psionic_transporter_remote",
-    "use_action": [  ],
-    "pocket_data": [  ],
-    "flags": [ "TRADER_AVOID" ]
+    "use_action": [],
+    "pocket_data": [],
+    "flags": ["TRADER_AVOID"]
   }
 ]

--- a/items/weapons.json
+++ b/items/weapons.json
@@ -1,7 +1,8 @@
 [
   {
     "id": "grenade_inferno",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "category": "weapons",
     "name": { "str": "inferno grenade" },
     "description": "This is an inferno grenade, designed to channel Netherum energy to increase its incendiary power.  Once you throw it, you will have five seconds to get away before it explodes into a raging firestorm.",
@@ -11,7 +12,7 @@
     "price_postapoc": "35 USD",
     "to_hit": -1,
     "melee_damage": { "bash": 6 },
-    "material": [ "steel", "nether_crystal" ],
+    "material": ["steel", "nether_crystal"],
     "symbol": "*",
     "color": "red",
     "use_action": {
@@ -23,11 +24,12 @@
       "menu_text": "Pull pin",
       "type": "transform"
     },
-    "flags": [ "BOMB", "ACT_IN_FIRE", "GRENADE" ]
+    "flags": ["BOMB", "ACT_IN_FIRE", "GRENADE"]
   },
   {
     "id": "grenade_inferno_act",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "category": "weapons",
     "name": { "str": "active inferno grenade" },
     "description": "This is an active inferno grenade.  Better throw it!",
@@ -37,7 +39,7 @@
     "price_postapoc": "0 cent",
     "to_hit": -1,
     "melee_damage": { "bash": 6 },
-    "material": [ "steel", "nether_crystal" ],
+    "material": ["steel", "nether_crystal"],
     "symbol": "*",
     "color": "red",
     "countdown_action": {
@@ -49,11 +51,12 @@
       "fields_max_intensity": 3
     },
     "revert_to": "canister_empty",
-    "flags": [ "ACT_IN_FIRE", "BOMB", "TRADER_AVOID", "DANGEROUS" ]
+    "flags": ["ACT_IN_FIRE", "BOMB", "TRADER_AVOID", "DANGEROUS"]
   },
   {
     "id": "grenade_inferno_makeshift",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "category": "weapons",
     "name": { "str": "makeshift inferno grenade" },
     "description": "This is a post-apocalyptic recreation of an inferno grenade, less powerful than a lab-made one but still very dangerous.  Once you throw it, you will have five seconds to get away before it explodes into a raging firestorm.",
@@ -63,7 +66,7 @@
     "price_postapoc": "15 USD",
     "to_hit": -1,
     "melee_damage": { "bash": 6 },
-    "material": [ "steel", "nether_crystal" ],
+    "material": ["steel", "nether_crystal"],
     "symbol": "*",
     "color": "red",
     "use_action": {
@@ -75,11 +78,12 @@
       "menu_text": "Pull pin",
       "type": "transform"
     },
-    "flags": [ "BOMB", "ACT_IN_FIRE", "GRENADE" ]
+    "flags": ["BOMB", "ACT_IN_FIRE", "GRENADE"]
   },
   {
     "id": "grenade_inferno_makeshift_act",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "category": "weapons",
     "name": { "str": "active makeshift inferno grenade" },
     "description": "This is an active makeshift inferno grenade.  Better throw it!",
@@ -89,7 +93,7 @@
     "price_postapoc": "0 cent",
     "to_hit": -1,
     "melee_damage": { "bash": 6 },
-    "material": [ "steel", "nether_crystal" ],
+    "material": ["steel", "nether_crystal"],
     "symbol": "*",
     "color": "red",
     "countdown_action": {
@@ -101,11 +105,12 @@
       "fields_max_intensity": 3
     },
     "revert_to": "canister_empty",
-    "flags": [ "ACT_IN_FIRE", "BOMB", "TRADER_AVOID", "DANGEROUS" ]
+    "flags": ["ACT_IN_FIRE", "BOMB", "TRADER_AVOID", "DANGEROUS"]
   },
   {
     "id": "grenade_anti_psi",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "category": "weapons",
     "looks_like": "grenade",
     "name": { "str": "null grenade" },
@@ -114,7 +119,7 @@
     "volume": "540 ml",
     "price": "10000 USD",
     "price_postapoc": "200 USD",
-    "material": [ "steel", "plastic", "nether_crystal" ],
+    "material": ["steel", "plastic", "nether_crystal"],
     "symbol": "*",
     "color": "dark_gray",
     "use_action": {
@@ -125,12 +130,13 @@
       "menu_text": "Push buttons",
       "type": "transform"
     },
-    "flags": [ "GRENADE" ],
+    "flags": ["GRENADE"],
     "melee_damage": { "bash": 6 }
   },
   {
     "id": "grenade_anti_psi_act",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "category": "weapons",
     "name": { "str": "active null grenade" },
     "description": "This null grenade is activate and ready to unleash its pulse.  You'd better throw it!",
@@ -139,19 +145,29 @@
     "price": "0 cent",
     "price_postapoc": "0 cent",
     "to_hit": -1,
-    "material": [ "steel", "plastic", "nether_crystal" ],
+    "material": ["steel", "plastic", "nether_crystal"],
     "symbol": "*",
     "color": "dark_gray",
-    "use_action": { "type": "message", "message": "The %s is already active, try throwing it instead.", "name": "Push buttons" },
-    "countdown_action": { "type": "cast_spell", "spell_id": "grenade_anti_psi_explosion", "no_fail": true, "level": 0 },
+    "use_action": {
+      "type": "message",
+      "message": "The %s is already active, try throwing it instead.",
+      "name": "Push buttons"
+    },
+    "countdown_action": {
+      "type": "cast_spell",
+      "spell_id": "grenade_anti_psi_explosion",
+      "no_fail": true,
+      "level": 0
+    },
     "countdown_interval": "5 seconds",
-    "flags": [ "BOMB", "TRADER_AVOID", "DANGEROUS" ],
+    "flags": ["BOMB", "TRADER_AVOID", "DANGEROUS"],
     "revert_to": "grenade_anti_psi_expended",
     "melee_damage": { "bash": 6 }
   },
   {
     "id": "grenade_anti_psi_expended",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "category": "weapons",
     "looks_like": "grenade",
     "name": { "str": "expended null grenade" },
@@ -160,14 +176,15 @@
     "volume": "540 ml",
     "price": "10000 USD",
     "price_postapoc": "0 USD",
-    "material": [ "steel", "plastic", "nether_crystal" ],
+    "material": ["steel", "plastic", "nether_crystal"],
     "symbol": "*",
     "color": "dark_gray",
     "melee_damage": { "bash": 6 }
   },
   {
     "id": "pyrokinetic_matrix_crystal_bomb",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "category": "weapons",
     "looks_like": "matrix_crystal_pyrokinesis",
     "copy-from": "matrix_crystal_pyrokinesis",
@@ -181,33 +198,44 @@
       "menu_text": "Overcharge the crystal",
       "type": "transform"
     },
-    "flags": [ "GRENADE" ]
+    "flags": ["GRENADE"]
   },
   {
     "id": "pyrokinetic_matrix_crystal_bomb_act",
-    "type": "TOOL",
+    "type": "ITEM",
+    "subtypes": ["TOOL"],
     "category": "weapons",
     "looks_like": "matrix_crystal_pyrokinesis",
     "copy-from": "matrix_crystal_pyrokinesis",
     "name": { "str": "destabilized pyrokinetic matrix crystal bomb" },
     "description": "A matrix crystal attuned to pyrokinesis.  The faint light in its depths is growing brighter and brighter, and the crystal itself is heating up as you hold it.",
-    "use_action": { "type": "message", "message": "The %s is already destabilized, try throwing it instead.", "name": "Push buttons" },
+    "use_action": {
+      "type": "message",
+      "message": "The %s is already destabilized, try throwing it instead.",
+      "name": "Push buttons"
+    },
     "countdown_action": {
       "type": "explosion",
-      "explosion": { "power": 120000, "fire": true, "shrapnel": 0, "max_noise": 25 },
+      "explosion": {
+        "power": 120000,
+        "fire": true,
+        "shrapnel": 0,
+        "max_noise": 25
+      },
       "fields_type": "fd_fire",
       "fields_radius": 10,
       "fields_min_intensity": 2,
       "fields_max_intensity": 3
     },
     "countdown_interval": "5 seconds",
-    "flags": [ "BOMB", "TRADER_AVOID", "DANGEROUS", "LIGHT_20" ],
+    "flags": ["BOMB", "TRADER_AVOID", "DANGEROUS", "LIGHT_20"],
     "melee_damage": { "bash": 6 }
   },
   {
     "id": "mom_pulse_rifle",
     "looks_like": "ar15",
-    "type": "GUN",
+    "type": "ITEM",
+    "subtypes": ["GUN"],
     "reload_noise_volume": 10,
     "name": { "str": "LV429 Pulse Rifle" },
     "description": "The LV429 fires a series of extremely short high-energy laser pulses, more like bullets than a traditional laser beam, greatly reducing dwell time and increasing weapon effectiveness.  Matrix crystal technology has made the weapon compact enough to be man-portable and provided it with enough power for essentially unlimited combat operations, but heat dissipation is still a problem, preventing it from being fired more than once every few seconds.",
@@ -218,7 +246,7 @@
     "price_postapoc": "65 USD",
     "to_hit": -1,
     "melee_damage": { "bash": 12 },
-    "material": [ "steel", "plastic", "nether_crystal" ],
+    "material": ["steel", "plastic", "nether_crystal"],
     "symbol": "(",
     "color": "cyan",
     "skill": "rifle",
@@ -229,39 +257,64 @@
     "heat_per_shot": 21,
     "recoil": 0,
     "durability": 4,
-    "modes": [ [ "DEFAULT", "semi-auto", 1 ] ],
+    "modes": [["DEFAULT", "semi-auto", 1]],
     "loudness": 5,
     "reload": 0,
     "clip_size": 1,
     "valid_mod_locations": [
-      [ "emitter", 1 ],
-      [ "grip", 1 ],
-      [ "rail", 1 ],
-      [ "sights", 1 ],
-      [ "sling", 1 ],
-      [ "stock", 1 ],
-      [ "stock accessory", 1 ],
-      [ "underbarrel", 1 ]
+      ["emitter", 1],
+      ["grip", 1],
+      ["rail", 1],
+      ["sights", 1],
+      ["sling", 1],
+      ["stock", 1],
+      ["stock accessory", 1],
+      ["underbarrel", 1]
     ],
-    "ammo": [ "mom_pulse_rifle_ammo" ],
-    "ammo_effects": [ "LASER", "IGNITE" ],
-    "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE", "NO_REPAIR", "OVERHEATS" ],
-    "faults": [ "fault_overheat_explosion", "fault_overheat_melting" ],
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "mom_pulse_rifle_ammo": 1 } } ],
-    "relic_data": { "charge_info": { "recharge_type": "periodic", "time": "8 s", "regenerate_ammo": true } },
+    "ammo": ["mom_pulse_rifle_ammo"],
+    "ammo_effects": ["LASER", "IGNITE"],
+    "flags": [
+      "NEVER_JAMS",
+      "NO_UNLOAD",
+      "NON_FOULING",
+      "NEEDS_NO_LUBE",
+      "NO_REPAIR",
+      "OVERHEATS"
+    ],
+    "faults": ["fault_overheat_explosion", "fault_overheat_melting"],
+    "pocket_data": [
+      {
+        "pocket_type": "MAGAZINE",
+        "ammo_restriction": { "mom_pulse_rifle_ammo": 1 }
+      }
+    ],
+    "relic_data": {
+      "charge_info": {
+        "recharge_type": "periodic",
+        "time": "8 s",
+        "regenerate_ammo": true
+      }
+    },
     "//": "Recharge time is 8 seconds due to bug #48019, making it actually 4 seconds. Reduce to 4 seconds if that ever gets fixed."
   },
   {
     "id": "mom_pulse_rifle_prototype",
     "looks_like": "ar15",
-    "type": "GUN",
+    "type": "ITEM",
+    "subtypes": ["GUN"],
     "copy-from": "mom_pulse_rifle",
     "name": { "str": "LV429-P Pulse Rifle" },
     "description": "The LV429 fires a series of extremely short high-energy laser pulses, more like bullets than a traditional laser beam, greatly reducing dwell time and increasing weapon effectiveness.  Matrix crystal technology has made the weapon compact enough to be man-portable and provided it with enough power for essentially unlimited operation.  This is a prototype, obvious from the bright red coloration of the barrel and grip, as well as the word \"prototype\" written in large letters on the stock and the flammable symbol next to it.",
     "overheat_threshold": 100,
     "cooling_value": 5,
     "heat_per_shot": 21,
-    "relic_data": { "charge_info": { "recharge_type": "periodic", "time": "2 s", "regenerate_ammo": true } },
+    "relic_data": {
+      "charge_info": {
+        "recharge_type": "periodic",
+        "time": "2 s",
+        "regenerate_ammo": true
+      }
+    },
     "//": "Recharge time is 2 seconds due to bug #48019, making it actually 1 second. Reduce to 1 seconds if that ever gets fixed."
   }
 ]

--- a/monsters/monster_special_attacks.json
+++ b/monsters/monster_special_attacks.json
@@ -6,7 +6,13 @@
     "move_cost": 80,
     "cooldown": 15,
     "accuracy": 5,
-    "damage_max_instance": [ { "damage_type": "psi_teleporter_teleporting_damage", "amount": 2, "armor_penetration": 10 } ],
+    "damage_max_instance": [
+      {
+        "damage_type": "psi_teleporter_teleporting_damage",
+        "amount": 2,
+        "armor_penetration": 10
+      }
+    ],
     "blockable": false,
     "hit_dmg_u": "%1$s touches you and the world warps around you!",
     "hit_dmg_npc": "%1$s touches <npcname> and the world warps around them!",
@@ -20,7 +26,9 @@
     "cooldown": 5,
     "move_cost": 100,
     "range": 3,
-    "damage_max_instance": [ { "damage_type": "psi_telepathic_damage", "amount": 10 } ],
+    "damage_max_instance": [
+      { "damage_type": "psi_telepathic_damage", "amount": 10 }
+    ],
     "hit_dmg_u": "%1$s shrieks at your %2$s!",
     "hit_dmg_npc": "%1$s shrieks at <npcname>!",
     "no_dmg_msg_u": "%1$s's shriek radiates out at you without doing any damage.",
@@ -35,7 +43,13 @@
     "cooldown": 15,
     "accuracy": 5,
     "range": 10,
-    "damage_max_instance": [ { "damage_type": "psi_telepathic_damage", "amount": 15, "armor_penetration": 0 } ],
+    "damage_max_instance": [
+      {
+        "damage_type": "psi_telepathic_damage",
+        "amount": 15,
+        "armor_penetration": 0
+      }
+    ],
     "dodgeable": false,
     "blockable": false,
     "hit_dmg_u": "%1$s looks at you and your mind reels!",
@@ -45,13 +59,14 @@
   },
   {
     "id": "feral_clair_thrown_rock",
-    "type": "GUN",
+    "type": "ITEM",
+    "subtypes": ["GUN"],
     "symbol": "%",
     "color": "red",
     "name": { "str": "hurled rubble" },
     "description": "Stone at the ready to crush that which isn't part of the blob.",
     "//": "Buffed stats account for the feral clairsentient using Marksman's Eye.",
-    "material": [ "stone" ],
+    "material": ["stone"],
     "flags": [
       "PRIMITIVE_RANGED_WEAPON",
       "NEVER_JAMS",
@@ -63,8 +78,8 @@
       "NO_TURRET"
     ],
     "skill": "throw",
-    "ammo": [ "rock" ],
-    "ammo_effects": [ "NO_PENETRATE_OBSTACLES", "NEVER_MISFIRES" ],
+    "ammo": ["rock"],
+    "ammo_effects": ["NO_PENETRATE_OBSTACLES", "NEVER_MISFIRES"],
     "ranged_damage": { "damage_type": "bash", "amount": -1 },
     "clip_size": 1,
     "weight": "540 g",
@@ -89,13 +104,14 @@
   },
   {
     "id": "pattern_screamer_thrown_rock",
-    "type": "GUN",
+    "type": "ITEM",
+    "subtypes": ["GUN"],
     "symbol": "%",
     "color": "red",
     "name": { "str": "hurled rubble" },
     "description": "Stone at the ready to crush that which isn't part of the blob.",
     "//": "Buffed stats account for the pattern screamer using One Perfect Shot / Marksman's Eye.",
-    "material": [ "stone" ],
+    "material": ["stone"],
     "flags": [
       "PRIMITIVE_RANGED_WEAPON",
       "NEVER_JAMS",
@@ -107,8 +123,8 @@
       "NO_TURRET"
     ],
     "skill": "throw",
-    "ammo": [ "rock" ],
-    "ammo_effects": [ "NO_PENETRATE_OBSTACLES", "NEVER_MISFIRES" ],
+    "ammo": ["rock"],
+    "ammo_effects": ["NO_PENETRATE_OBSTACLES", "NEVER_MISFIRES"],
     "ranged_damage": { "damage_type": "bash", "amount": 8 },
     "clip_size": 1,
     "weight": "540 g",


### PR DESCRIPTION
## Description
There was a recent series of backports that changed how items were typed to reduce redundancies; this PR enforces these changes.

## PR Type
- [x] Bug Fix
- [ ] Code Refactor
- [ ] Doc Changes
- [ ] New Asset(s)
- [ ] New Feature(s)

## PR Size
- [ ] One-line
- [ ] Small
- [ ] Medium
- [x] Large

## Testing
Tested on a new world and no errors occurred, with the exception of the wristwatch itemgroup one. 

## Notes
Relevant PRs:
https://github.com/Cataclysm-TLG/Cataclysm-TLG/pull/1965
https://github.com/Cataclysm-TLG/Cataclysm-TLG/pull/1966
https://github.com/Cataclysm-TLG/Cataclysm-TLG/pull/1967
https://github.com/Cataclysm-TLG/Cataclysm-TLG/pull/1968