### PR TITLE
Replace Refs to `esoteric_books` With `exotic_books`

### DIFF
--- a/itemgroups/books.json
+++ b/itemgroups/books.json
@@ -96,8 +96,8 @@
     "items": [ [ "satellitemap", 3 ], [ "roadmap", 2 ], [ "subwaystationmap", 1 ], [ "militarymap", 2 ], [ "sewermap", 1 ] ]
   },
   {
-    "id": "esoteric_books",
-    "copy-from": "esoteric_books",
+    "id": "exotic_books",
+    "copy-from": "exotic_books",
     "type": "item_group",
     "extend": {
       "items": [ { "group": "dist_meditation_books_begin", "prob": 25 }, { "group": "dist_meditation_books_int", "prob": 10 } ]


### PR DESCRIPTION
## Description
See title. `esoteric_books` was depreciated at some point.

## PR Type
- [x] Bug Fix
- [ ] Code Refactor
- [ ] Doc Changes
- [ ] New Asset(s)
- [ ] New Feature(s)

## PR Size
- [x] One-line
- [ ] Small
- [ ] Medium
- [ ] Large

## Testing
No errors on chargen/worldgen.

## Notes
...