### PR TITLE
Fix `matrix_shard` Not Being Consumed on Activation

### DIFF
--- a/items/matrix_crystals.json
+++ b/items/matrix_crystals.json
@@ -361,7 +361,7 @@
       "practice": 2,
       "done_message": "You carefully place the shards on the ground, ready to be cracked by something passing by."
     },
-    "flags": ["HURT_WHEN_WIELDED", "TRADER_AVOID"],
+    "flags": ["HURT_WHEN_WIELDED", "TRADER_AVOID", "SINGLE_USE"],
     "to_hit": -1
   }
 ]


### PR DESCRIPTION
## Description
See title. Fix was giving it the 'SINGLE_USE' flag.

## PR Type
- [x] Bug Fix
- [ ] Code Refactor
- [ ] Doc Changes
- [ ] New Asset(s)
- [ ] New Feature(s)

## PR Size
- [x] One-line
- [ ] Small
- [ ] Medium
- [ ] Large

## Testing
Image shows before (bottom) and after (top) the changes were applied.
<img width="320" height="397" alt="image" src="https://github.com/user-attachments/assets/d8d326cf-104f-4995-aa76-651f7edf0685" />


## Notes
<img width="1377" height="477" alt="image" src="https://github.com/user-attachments/assets/b3640486-f2da-4192-bcd4-60d2272eecb4" />