### PR TITLE
One potential fix for the Wakeful Rest never ending meditation issue

### DIFF
--- a/powers/vitakinesis_eoc.json
+++ b/powers/vitakinesis_eoc.json
@@ -216,7 +216,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_VITAKIN_SLEEP",
-    "condition": { "or": [ { "math": [ "u_val('fatigue') + u_val('sleep_deprivation')", ">=", "0" ] } ] },
+    "condition": { "or": [ { "math": [ "u_val('fatigue') + u_val('sleep_deprivation')", ">", "0" ] } ] },
     "effect": [
       { "u_assign_activity": "ACT_VITAKIN_WAKEFUL_REST_MEDITATE", "duration": "510 minutes" },
       { "u_add_effect": "effect_vitakin_wakeful_resting", "duration": "510 minutes" },
@@ -259,7 +259,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_VITAKIN_WAKEFUL_REST_MEDITATE",
-    "condition": { "math": [ "u_val('fatigue') + u_val('sleep_deprivation')", ">=", "0" ] },
+    "condition": { "math": [ "u_val('fatigue') + u_val('sleep_deprivation')", ">", "0" ] },
     "effect": [ { "run_eocs": [ "EOC_VITAKIN_SLEEP_SLEEPINESS", "EOC_VITAKIN_SLEEP_DEPRIVATION" ] } ],
     "false_effect": [
       {


### PR DESCRIPTION
## Description
A change to address https://github.com/Vegetabs/MindOverMatter-CTLG/issues/94 . Change the conditions on wakeful rest meditation EOC start and EOC end from "fatigue+sleep deprivation greater than or equal to 0" to just "fatigue+sleep deprivation greater than 0".

## PR Type
- [X] Bug Fix
- [ ] Code Refactor
- [ ] Doc Changes
- [ ] New Asset(s)
- [ ] New Feature(s)

## PR Size
- [ ] One-line
- [X] Small
- [ ] Medium
- [ ] Large

## Testing
Use the Wakeful Rest power both at 0 fatigue and sleep depreviation and with greater than 0 fatigue and/or sleep deprivation.

## Notes
I marked "small" rather than "one-line" but it was only two characters I changed. This change brings the behavior back to how it was before but I'm not sure if the fatigue cap means the power needs more tweaking beyond this.