### PR TITLE
Remove Refs to `stim`

### DIFF
--- a/effects/effects_monster.json
+++ b/effects/effects_monster.json
@@ -295,7 +295,7 @@
     "id": "pigeon_aura",
     "name": [ "" ],
     "blood_analysis_description": "Blood sample contains noetic steroid particles and pigeon dander.",
-    "base_mods": { "str_mod": [ 1 ], "stim_amount": [ 1 ], "stim_tick": [ 500 ], "stim_max_val": [ 10 ] }
+    "base_mods": { "str_mod": [ 1 ] }
   },
   {
     "type": "effect_type",


### PR DESCRIPTION
## Description
Removed obsolete refs to `stim` in `pigeon_aura`.

## PR Type
- [x] Bug Fix
- [ ] Code Refactor
- [ ] Doc Changes
- [ ] New Asset(s)
- [ ] New Feature(s)

## PR Size
- [x] One-line
- [ ] Small
- [ ] Medium
- [ ] Large

## Testing
...

## Notes
...